### PR TITLE
Release FoundationPose data prep: extract, 3D bbox, and Qwen classifications

### DIFF
--- a/scripts/data_prep/foundationpose/EXTRACTED_FORMAT.md
+++ b/scripts/data_prep/foundationpose/EXTRACTED_FORMAT.md
@@ -1,0 +1,456 @@
+# FoundationPose GSO Dataset - Data Format Documentation
+
+Base directory: `/weka/oe-training-default/weikaih/molmo_detection_curation/data/foundationpose_extracted/`
+
+---
+
+## Naming Convention
+
+All per-view files follow the pattern:
+```
+{group_id}_scene_{scene_id:08d}_cam_{cam_id}.{ext}
+```
+- `group_id`: Numeric scene group identifier (e.g., `1004491151`)
+- `scene_id`: 8-digit zero-padded scene index (e.g., `00000412`)
+- `cam_id`: Camera index (`0` or `1` — two cameras per scene)
+
+Example: `4280099961_scene_00000412_cam_1.png`
+
+Per-scene files (no camera dimension):
+```
+{group_id}_scene_{scene_id:08d}_states.json
+```
+
+---
+
+## 1. Images
+
+**Location:** `images/gso/`
+**Count:** 446,228 files
+**Format:** PNG (RGBA), 640 x 480 pixels
+
+```
+4280099961_scene_00000412_cam_1.png
+```
+
+---
+
+## 2. Depth Maps
+
+**Location:** `depth/gso/`
+**Count:** 446,232 files
+**Format:** NumPy `.npy`, float32, shape `(480, 640)`
+
+- **Units:** Meters (scene unit = 1 meter, see `metersPerSceneUnit` in camera params)
+- **Invalid pixels:** `inf` (background / out-of-range)
+- **Typical range:** ~1.8 - 3.5 meters
+
+```python
+depth = np.load("1004491151_scene_00000000_cam_0.npy")
+# dtype: float32, shape: (480, 640)
+# valid range: 1.805 - 3.212 meters
+# background: inf
+```
+
+> **Note:** The reference datasets (COCO/Objects365/LVIS) at
+> `v4_depth/` store depth as float32 `.npy` in **millimeters** with
+> filename pattern `{image_id:012d}_sr_1024_long.npy` and variable
+> resolution (up to 1024 on the long edge). FoundationPose stores depth
+> in **meters** at a fixed 640x480.
+
+---
+
+## 3. Camera Parameters
+
+**Location:** `camera_params/gso/`
+**Count:** 446,232 files
+**Format:** JSON
+
+```json
+{
+  "cameraAperture": [22.53, 15.29],
+  "cameraApertureOffset": [0.0, 0.0],
+  "cameraFisheyeLensP": [],
+  "cameraFisheyeLensS": [],
+  "cameraFisheyeMaxFOV": 0.0,
+  "cameraFisheyeNominalHeight": 0,
+  "cameraFisheyeNominalWidth": 0,
+  "cameraFisheyeOpticalCentre": [0.0, 0.0],
+  "cameraFisheyePolynomial": [0.0, 0.0, 0.0, 0.0, 0.0],
+  "cameraFocalLength": 34.54,
+  "cameraFocusDistance": 321.90,
+  "cameraFStop": 0.0,
+  "cameraModel": "pinhole",
+  "cameraNearFar": [0.01, 1000000.0],
+  "cameraProjection": [
+    3.066, 0.0, 0.0, 0.0,
+    0.0, 4.089, 0.0, 0.0,
+    0.0, 0.0, 1e-08, -1.0,
+    0.0, 0.0, 0.01, 0.0
+  ],
+  "cameraViewTransform": [
+    -0.177, -0.711, 0.681, 0.0,
+    0.984, -0.128, 0.122, 0.0,
+    0.0, 0.692, 0.722, 0.0,
+    0.0, 0.0, -2.461, 1.0
+  ],
+  "metersPerSceneUnit": 1.0,
+  "renderProductResolution": [640, 480]
+}
+```
+
+### Key fields
+
+| Field | Description |
+|-------|-------------|
+| `cameraModel` | Always `"pinhole"` |
+| `cameraProjection` | 4x4 projection matrix, stored as flat 16-element array (row-major). `P[0]=fx_ndc`, `P[5]=fy_ndc`. To get pixel focal lengths: `fx = P[0] * width/2`, `fy = P[5] * height/2` |
+| `cameraViewTransform` | 4x4 world-to-camera view matrix, flat 16-element array (row-major, row-vector convention). Translation is in the last row. Multiply as `p_cam = p_world @ V` |
+| `renderProductResolution` | `[width, height]` = `[640, 480]` |
+| `metersPerSceneUnit` | Scale factor, always `1.0` (depth values are already in meters) |
+| `cameraFocalLength` | Physical focal length in scene units (mm-equivalent) |
+
+### Camera space convention (OpenGL)
+
+Isaac Sim uses **OpenGL** camera space, NOT OpenCV:
+- **X**: right
+- **Y**: up (opposite to OpenCV)
+- **Z**: into the screen is negative (camera looks along **-Z**)
+
+This affects unprojection and any conversions to/from OpenCV camera space (X-right, Y-down, Z-forward).
+
+### Deriving intrinsics
+
+```python
+P = np.array(cam["cameraProjection"]).reshape(4, 4)
+w, h = cam["renderProductResolution"]
+fx = P[0, 0] * w / 2   # ~981 pixels
+fy = P[1, 1] * h / 2   # ~981 pixels
+cx = w / 2              # 320
+cy = h / 2              # 240
+```
+
+### Unprojection (pixel + depth → 3D)
+
+Because the camera is in OpenGL convention, unprojection from pixel coordinates
+`(px, py)` with metric depth `d` (in meters) is:
+
+```python
+X_gl = (px - cx) * d / fx
+Y_gl = -(py - cy) * d / fy   # note negation (Y-up vs pixel Y-down)
+Z_gl = -d                     # camera looks along -Z
+```
+
+To convert to **OpenCV camera space** (X-right, Y-down, Z-forward):
+```python
+X_cv = X_gl
+Y_cv = -Y_gl
+Z_cv = -Z_gl
+```
+
+### Projection (world → pixel)
+
+```python
+p_clip = p_world @ V @ P          # row-vector convention
+ndc = p_clip[:2] / p_clip[3]      # perspective divide (clip_w = -z_eye for OpenGL)
+px = (ndc[0] + 1) / 2 * width
+py = (1 - ndc[1]) / 2 * height    # flip Y: NDC Y-up → pixel Y-down
+```
+
+> **Reference format (COCO/Objects365/LVIS):** Camera params are stored
+> as JSON at `v4_depth/{dataset}/{split}/camera_params/{image_id:012d}.json`:
+> ```json
+> {
+>   "intrinsics": [[fx, s, cx], [0, fy, cy], [0, 0, 1]],
+>   "depth_size": [H, W],
+>   "image_size": [H, W],
+>   "rotation": [[3x3]],
+>   "translation": [x, y, z]
+> }
+> ```
+> Intrinsics are given directly as a 3x3 matrix in pixel coordinates.
+
+---
+
+## 4. Instance Segmentation Masks
+
+**Location:** `masks/gso/`
+**Count:** 446,232 files
+**Format:** PNG, 16-bit grayscale (`I;16`), 640 x 480 pixels
+
+Pixel values are semantic instance IDs:
+- `0` = Background
+- `1` = Unlabelled
+- `2+` = Object instances (mapped via instance mappings)
+
+```python
+mask = np.array(Image.open("...cam_0.png"))
+# dtype: uint16, shape: (480, 640)
+# unique values example: [0, 1, 4, 10, 11, 12, ..., 27]
+```
+
+---
+
+## 5. 2D Bounding Boxes
+
+**Location:** `bounding_boxes/gso/{tight,loose}/`
+**Count:** 163,594 (tight), 446,232 (loose)
+**Format:** NumPy structured array `.npy`
+
+```python
+dtype = np.dtype([
+    ('semanticId', '<u4'),       # Instance ID (matches mask pixel values)
+    ('x_min',      '<i4'),       # Left edge (pixels)
+    ('y_min',      '<i4'),       # Top edge (pixels)
+    ('x_max',      '<i4'),       # Right edge (pixels, inclusive)
+    ('y_max',      '<i4'),       # Bottom edge (pixels, inclusive)
+    ('occlusionRatio', '<f4'),   # Fraction of object occluded [0.0, 1.0]
+])
+```
+
+Sample:
+```python
+bbox = np.load("1004491151_scene_00000000_cam_0.npy")
+# shape: (19,)
+# bbox[0] = (semanticId=0, x_min=0, y_min=0, x_max=639, y_max=479, occlusionRatio=0.348)
+# bbox[2] = (semanticId=2, x_min=348, y_min=239, x_max=423, y_max=323, occlusionRatio=0.285)
+```
+
+- **semanticId=0** is background (spans full image), skip when processing objects
+- **tight** boxes fit closely around the visible mask; **loose** boxes include padding
+- Not all images have tight boxes (163K vs 446K)
+
+> **Warning:** The `semanticId` values in the bbox `.npy` files use a **different**
+> numbering than the mask PNG pixel values. The bbox `semanticId` is an index into
+> the `bounding_box_paths/` annotation arrays, NOT the mask semantic ID. Always
+> derive object identity from **mask + instance_mapping** files, which are the
+> authoritative source for semantic IDs.
+
+---
+
+## 6. 3D Object Poses (Scene Data)
+
+**Location:** `scene_data/gso/`
+**Count:** 449,469 files
+**Format:** JSON, one per scene (shared across both cameras)
+
+```json
+{
+  "collision_box": {
+    "prim_path": "/World/collision_box",
+    "name": "collision_box",
+    "position": [0.0, 0.0, 1.305],
+    "width": 1.042,
+    "height": 1.968,
+    "depth": 2.610,
+    "visible": true,
+    "distribution": "normal"
+  },
+  "objects": {
+    "ASICS_GELBlur33_20_GS_BlackWhiteSafety_Orange": {
+      "prim_path": "/World/objects/gso_ASICS_GELBlur33_20_GS_...",
+      "scale": [0.124, 0.124, 0.124],
+      "translation": [-0.036, -0.009, 0.054],
+      "rotation_matrix": [
+        [-0.043, 0.028, 0.113],
+        [-0.032, -0.118, 0.018],
+        [0.112, -0.023, 0.048]
+      ],
+      "transform_matrix_world": [
+        [-0.043, -0.032, 0.112, 0.0],
+        [0.028, -0.118, -0.023, 0.0],
+        [0.113, 0.018, 0.048, 0.0],
+        [-0.036, -0.009, 0.054, 1.0]
+      ]
+    }
+  }
+}
+```
+
+### Object fields
+
+| Field | Description |
+|-------|-------------|
+| `prim_path` | USD primitive path. Format: `/World/objects/gso_{AssetName}` |
+| `scale` | `[sx, sy, sz]` — scale factors (often uniform) |
+| `translation` | `[tx, ty, tz]` — position in world coordinates (meters) |
+| `rotation_matrix` | 3x3 rotation matrix (includes scale: column norms = scale) |
+| `transform_matrix_world` | 4x4 homogeneous transform. Row-vector convention: `p_world = p_local * M`. Upper-left 3x3 = rotation (transposed relative to `rotation_matrix` columns). Last row = `[tx, ty, tz, 1.0]` |
+
+### collision_box
+
+Defines the table/surface where objects are placed:
+- `position`: Center of the box in world coordinates
+- `width`, `height`, `depth`: Dimensions of the placement surface
+
+---
+
+## 7. Instance Mappings
+
+**Location:** `annotations/instance_mappings/gso/`
+
+### mapping.json
+Maps semantic IDs (from masks) to USD prim paths.
+
+```json
+{
+  "0": "BACKGROUND",
+  "1": "UNLABELLED",
+  "4": "/World/collision_box/collision_box_floor",
+  "10": "/World/objects/gso_Perricone_MD_Nutritive_Cleanser/model/mesh",
+  "11": "/World/objects/gso_Phillips_Caplets_Size_24/model/mesh"
+}
+```
+
+Asset name extraction: `prim_path.split('/')[3]` gives `gso_Perricone_MD_Nutritive_Cleanser`
+
+### semantics.json
+Maps semantic IDs to lowercased class names.
+
+```json
+{
+  "0": {"class": "BACKGROUND"},
+  "1": {"class": "UNLABELLED"},
+  "10": {"class": "world_objects_gso_perricone_md_nutritive_cleanser_model_mesh"}
+}
+```
+
+---
+
+## 8. Bounding Box Path Annotations
+
+**Location:** `annotations/bounding_box_paths/gso/`
+
+### labels.json / tight_labels.json
+Maps bbox array index to class name.
+
+```json
+{
+  "0": {"class": "world_collision_box_collision_box_floor"},
+  "1": {"class": "world_objects_gso_heavyduty_flashlight_model_mesh"},
+  "2": {"class": "world_objects_gso_wilton_easy_layers_cake_pan_set_model_mesh"}
+}
+```
+
+### tight_paths.json / loose_paths.json
+Array of prim paths in bbox order.
+
+```json
+[
+  "/World/collision_box/collision_box_floor",
+  "/World/objects/gso_BREAKFAST_MENU/model/mesh",
+  "/World/objects/gso_Travel_Mate_P_series_Notebook/model/mesh"
+]
+```
+
+Index `i` in this array corresponds to `bbox_data[i]` in the `.npy` file.
+
+---
+
+## 9. Occlusion Data
+
+**Location:** `occlusion/gso/`
+**Count:** 163,594 files
+**Format:** NumPy structured array `.npy`
+
+```python
+dtype = np.dtype([
+    ('instanceId',     '<u4'),  # Unique instance ID
+    ('semanticId',     '<u4'),  # Semantic class ID (from mask)
+    ('occlusionRatio', '<f4'),  # Occlusion ratio [0.0, 1.0]
+])
+```
+
+---
+
+## 10. Qwen VLM Classifications
+
+**Location:** `qwen_classifications_v2/gso_qwen_classifications_v2.json`
+**Format:** JSON
+
+```json
+{
+  "dataset": "gso",
+  "status": "completed",
+  "total_assets": 928,
+  "successful": 866,
+  "uncertain": 62,
+  "failed": 0,
+  "results": [
+    {
+      "asset_name": "gso_AMBERLIGHT_UP_W",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": ["crop_005.png"],
+      "total_views_available": 8395,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a high-top athletic shoe with a blue upper..."
+    }
+  ]
+}
+```
+
+- 928 unique GSO assets classified
+- `qwen_classification`: category label, or `"category (uncertain)"` for low-confidence
+- Maps to objects via `asset_name` matching the prim path component (e.g., `gso_AMBERLIGHT_UP_W`)
+
+---
+
+## Cross-referencing Data
+
+To connect all annotations for a single image:
+
+```python
+stem = "1004491151_scene_00000000_cam_0"
+
+image     = Image.open(f"images/gso/{stem}.png")
+depth     = np.load(f"depth/gso/{stem}.npy")
+mask      = np.array(Image.open(f"masks/gso/{stem}.png"))
+bbox      = np.load(f"bounding_boxes/gso/tight/{stem}.npy")
+cam       = json.load(open(f"camera_params/gso/{stem}.json"))
+mapping   = json.load(open(f"annotations/instance_mappings/gso/{stem}_mapping.json"))
+
+# Scene data (shared across both cameras)
+scene_id  = "_".join(stem.split("_")[:-2])  # "1004491151_scene_00000000"
+scene     = json.load(open(f"scene_data/gso/{scene_id}_states.json"))
+
+# For each bbox entry:
+for row in bbox:
+    sem_id = int(row["semanticId"])
+    if sem_id == 0:  # skip background
+        continue
+    prim_path = mapping.get(str(sem_id), "")
+    asset_name = prim_path.split("/")[3] if len(prim_path.split("/")) >= 4 else None
+
+    # 2D bbox
+    x_min, y_min, x_max, y_max = row["x_min"], row["y_min"], row["x_max"], row["y_max"]
+
+    # 3D pose (from scene data, using object name without gso_ prefix)
+    obj_name = asset_name.replace("gso_", "") if asset_name else None
+    if obj_name and obj_name in scene["objects"]:
+        obj = scene["objects"][obj_name]
+        transform = np.array(obj["transform_matrix_world"])  # 4x4
+
+    # Qwen label
+    qwen_label = cls_lookup.get(asset_name, "unknown")
+
+    # Mask pixels
+    obj_pixels = (mask == sem_id)
+```
+
+---
+
+## Comparison with Reference Datasets (COCO / Objects365 / LVIS)
+
+| Aspect | FoundationPose GSO | COCO / Objects365 / LVIS |
+|--------|-------------------|--------------------------|
+| **Depth format** | float32 `.npy`, meters, (480, 640) fixed | float32 `.npy`, millimeters, variable resolution (up to 1024 long edge) |
+| **Depth naming** | `{group}_scene_{id}_cam_{c}.npy` | `{image_id:012d}_sr_1024_long.npy` |
+| **Camera params** | Full Isaac Sim camera JSON (projection matrix, view transform, aperture, etc.) | Minimal JSON: `{intrinsics, depth_size, image_size, rotation, translation}` |
+| **Intrinsics** | Derived from `cameraProjection` matrix | Given directly as 3x3 `intrinsics` matrix |
+| **2D boxes** | NumPy structured array `.npy` per image | COCO-format JSON annotation file (shared for all images) |
+| **Segmentation** | 16-bit PNG masks (per-pixel instance IDs) | Polygon or RLE in annotation JSON |
+| **3D poses** | Full 4x4 transform per object in `scene_data` JSON | 3D bboxes from monocular estimation pipeline |
+| **Categories** | 928 unique asset names, Qwen-classified | Fixed category sets (80/365/1203) |
+| **Image resolution** | Fixed 640x480 | Variable |

--- a/scripts/data_prep/foundationpose/README.md
+++ b/scripts/data_prep/foundationpose/README.md
@@ -1,0 +1,86 @@
+# FoundationPose data preparation
+
+The WildDet3D-Data synthetic split includes a portion derived from the
+FoundationPose GSO renderings. Preparing that split from the official
+FoundationPose Google Drive release requires three steps:
+
+```
+raw FoundationPose .zip   ──Step 1──>   foundationpose_extracted/    ──Step 2──>   foundationpose_3dbbox/gso/   ──Step 3──>   Omni3D-style annotations
+(Google Drive download)                 images/, depth/, masks/,                   step30_result_{img_id}.json                 used by the WildDet3D training pipeline
+                                        camera_params/, metadata/, ...
+```
+
+This directory contains one script per step.
+
+## Step 1 — Extract the raw FoundationPose archive
+
+Script: `extract_foundationpose.py`
+
+Takes the raw zip archives downloaded from the official FoundationPose Google
+Drive release and lays them out into the structured directory used by Step 2.
+
+```
+python extract_foundationpose.py \
+    --source <dir-with-FoundationPose-zips> \
+    --output <foundationpose_extracted> \
+    --dataset gso \
+    --workers 32
+```
+
+The resulting `<foundationpose_extracted>/` directory follows the format
+documented in `EXTRACTED_FORMAT.md` (per-frame `images/`, `depth/`,
+`camera_params/`, `masks/`, `metadata/`, plus per-scene `scene_data/`,
+`bounding_boxes/`, etc.).
+
+## Step 2 — Generate per-image 3D bbox JSONs
+
+Script: `convert_gso_to_3dbbox.py`
+
+Reads the extracted directory and produces one `step30_result_{image_id}.json`
+per image, matching the per-image 3D bbox format used by the COCO / Objects365
+/ LVIS preprocessing pipelines.
+
+```
+python convert_gso_to_3dbbox.py \
+    --base_dir <foundationpose_extracted> \
+    --output_dir <foundationpose_3dbbox/gso> \
+    --workers 32
+```
+
+Each output JSON contains `boxes3d`, `boxes2d`, `categories`, and per-object
+metadata. See the header of the script for the coordinate convention.
+
+This step assigns each GSO asset a natural-language category using a Qwen
+VLM. To avoid forcing every user to re-run the VLM, the pre-computed
+classifications for all 928 GSO assets are shipped alongside this script as
+`gso_qwen_classifications_v2.json` and are picked up automatically. You can
+override with `--qwen_classifications <path>` if you regenerate them.
+
+## Step 3 — Convert to Omni3D-style annotations
+
+Script: `convert_foundationpose_fast.py`
+
+Combines the Step 1 output (images + camera params) with the Step 2 output
+(3D bbox JSONs) to produce the Omni3D-style annotation JSON consumed by the
+WildDet3D training pipeline.
+
+```
+python convert_foundationpose_fast.py \
+    --bbox3d_dir <foundationpose_3dbbox/gso> \
+    --extracted_dir <foundationpose_extracted> \
+    --output_dir <data/foundationpose/annotations>
+```
+
+After this step the FoundationPose subset is in the same format as the other
+synthetic sources in WildDet3D-Data and can be loaded by the standard
+WildDet3D dataset class.
+
+## Reference layout after all three steps
+
+```
+data/foundationpose/
+├── images/            # symlinked or copied from <foundationpose_extracted>/images/gso
+├── depth/             # from <foundationpose_extracted>/depth/gso
+├── camera_params/     # from <foundationpose_extracted>/camera_params/gso
+└── annotations/       # Step 3 output (Omni3D-style)
+```

--- a/scripts/data_prep/foundationpose/convert_gso_to_3dbbox.py
+++ b/scripts/data_prep/foundationpose/convert_gso_to_3dbbox.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+Convert FoundationPose GSO dataset to 3D bounding box format.
+
+Produces one JSON per image matching the reference format used by
+COCO/Objects365/LVIS 3D bbox datasets (step30_result_{image_id}.json).
+
+Output format per image:
+{
+  "image_id": str,
+  "boxes3d": [[{"box3d": [cx, cy, cz, w, h, l, qw, qx, qy, qz]}], ...],
+  "boxes2d": [[x1, y1, x2, y2], ...],
+  "categories": [str, ...],
+  "category_certain": [bool, ...],
+  "num_candidates": [int, ...]
+}
+
+box3d conventions (matching box3d_utils.py):
+  (cx, cy, cz): center in OpenCV camera space (X-right, Y-down, Z-forward), meters
+  (w, h, l): width(X), height(Y), length(Z) in box's local frame, meters
+  (qw, qx, qy, qz): scalar-first quaternion, rotation from box local -> camera frame
+
+Coordinate pipeline:
+  Pixel + depth -> OpenGL camera (Isaac Sim native)
+  OpenGL camera -> World (via V_inv)
+  World -> Scaled object local (via pure rotation inverse)
+  AABB in scaled local -> metric (w, h, l)
+  Rotation: scaled local -> OpenCV camera (via R_pure, V, flip)
+"""
+
+import argparse
+import json
+import os
+import sys
+import numpy as np
+from PIL import Image
+from multiprocessing import Pool
+from pathlib import Path
+import time
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def rotation_matrix_to_quaternion(R):
+    """Convert 3x3 rotation matrix to [qw, qx, qy, qz] quaternion (scalar-first).
+
+    Uses Shepperd's method, matching box3d_utils.py.
+    """
+    trace = np.trace(R)
+    if trace > 0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        qw = 0.25 / s
+        qx = (R[2, 1] - R[1, 2]) * s
+        qy = (R[0, 2] - R[2, 0]) * s
+        qz = (R[1, 0] - R[0, 1]) * s
+    elif R[0, 0] > R[1, 1] and R[0, 0] > R[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R[0, 0] - R[1, 1] - R[2, 2])
+        qw = (R[2, 1] - R[1, 2]) / s
+        qx = 0.25 * s
+        qy = (R[0, 1] + R[1, 0]) / s
+        qz = (R[0, 2] + R[2, 0]) / s
+    elif R[1, 1] > R[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R[1, 1] - R[0, 0] - R[2, 2])
+        qw = (R[0, 2] - R[2, 0]) / s
+        qx = (R[0, 1] + R[1, 0]) / s
+        qy = 0.25 * s
+        qz = (R[1, 2] + R[2, 1]) / s
+    else:
+        s = 2.0 * np.sqrt(1.0 + R[2, 2] - R[0, 0] - R[1, 1])
+        qw = (R[1, 0] - R[0, 1]) / s
+        qx = (R[0, 2] + R[2, 0]) / s
+        qy = (R[1, 2] + R[2, 1]) / s
+        qz = 0.25 * s
+    return np.array([qw, qx, qy, qz])
+
+
+def load_qwen_classifications(base_dir, qwen_path=None):
+    """Load Qwen v2 classifications into {asset_name: (category, certain)} dict.
+
+    Resolution order:
+    1. Explicit path passed via --qwen_classifications.
+    2. {base_dir}/qwen_classifications_v2/gso_qwen_classifications_v2.json
+    3. gso_qwen_classifications_v2.json co-located with this script
+       (released alongside the data-prep scripts; covers all 928 GSO assets).
+    """
+    candidates = []
+    if qwen_path is not None:
+        candidates.append(qwen_path)
+    candidates.append(
+        os.path.join(
+            base_dir, "qwen_classifications_v2", "gso_qwen_classifications_v2.json"
+        )
+    )
+    candidates.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "gso_qwen_classifications_v2.json",
+        )
+    )
+    for path in candidates:
+        if os.path.exists(path):
+            with open(path) as f:
+                data = json.load(f)
+            lookup = {}
+            for result in data["results"]:
+                asset_name = result["asset_name"]
+                raw_class = result["qwen_classification"]
+                certain = "(uncertain)" not in raw_class
+                category = raw_class.replace(" (uncertain)", "")
+                lookup[asset_name] = (category, certain)
+            logger.info(f"Loaded Qwen classifications from {path}")
+            return lookup
+    raise FileNotFoundError(
+        "Could not locate gso_qwen_classifications_v2.json. Tried: "
+        + ", ".join(candidates)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Worker state (initialized once per process)
+# ---------------------------------------------------------------------------
+_worker_state = {}
+
+
+def init_worker(base_dir, output_dir, min_mask_pixels, qwen_path=None):
+    """Initialize worker process with shared data."""
+    _worker_state["base_dir"] = base_dir
+    _worker_state["output_dir"] = output_dir
+    _worker_state["min_mask_pixels"] = min_mask_pixels
+    _worker_state["qwen"] = load_qwen_classifications(base_dir, qwen_path)
+    _worker_state["scene_cache"] = {}
+
+
+def get_scene_data(scene_stem):
+    """Load scene data with per-worker caching."""
+    cache = _worker_state["scene_cache"]
+    if scene_stem not in cache:
+        path = os.path.join(
+            _worker_state["base_dir"],
+            "scene_data",
+            "gso",
+            f"{scene_stem}_states.json",
+        )
+        if os.path.exists(path):
+            with open(path) as f:
+                cache[scene_stem] = json.load(f)
+        else:
+            cache[scene_stem] = None
+    return cache[scene_stem]
+
+
+# OpenGL -> OpenCV flip: negate Y and Z
+_F = np.diag([1.0, -1.0, -1.0])
+
+
+def process_image(stem):
+    """Process a single image and produce a step30_result JSON.
+
+    Returns a dict with status and metadata for aggregation.
+    """
+    base_dir = _worker_state["base_dir"]
+    output_dir = _worker_state["output_dir"]
+    min_mask_pixels = _worker_state["min_mask_pixels"]
+    qwen = _worker_state["qwen"]
+
+    # Resumability: skip if output already exists
+    out_path = os.path.join(output_dir, f"step30_result_{stem}.json")
+    if os.path.exists(out_path):
+        return {"status": "skipped", "stem": stem}
+
+    try:
+        # --- Load all inputs ---
+        mask_path = os.path.join(base_dir, "masks", "gso", f"{stem}.png")
+        depth_path = os.path.join(base_dir, "depth", "gso", f"{stem}.npy")
+        cam_path = os.path.join(base_dir, "camera_params", "gso", f"{stem}.json")
+        mapping_path = os.path.join(
+            base_dir,
+            "annotations",
+            "instance_mappings",
+            "gso",
+            f"{stem}_mapping.json",
+        )
+
+        for p in [mask_path, depth_path, cam_path, mapping_path]:
+            if not os.path.exists(p):
+                return {"status": "missing_file", "stem": stem, "file": p}
+
+        mask = np.array(Image.open(mask_path))  # uint16 (480, 640)
+        depth = np.load(depth_path)  # float32 (480, 640)
+        with open(cam_path) as f:
+            cam = json.load(f)
+        with open(mapping_path) as f:
+            mapping = json.load(f)
+
+        # Scene data (shared across cam_0 / cam_1)
+        # stem = "{group}_scene_{id}_cam_{c}"
+        parts = stem.rsplit("_", 2)  # ["{group}_scene_{id}", "cam", "{c}"]
+        scene_stem = parts[0]
+        scene_data = get_scene_data(scene_stem)
+        if scene_data is None:
+            return {"status": "no_scene_data", "stem": stem}
+
+        # --- Camera params ---
+        V = np.array(cam["cameraViewTransform"]).reshape(4, 4)
+        P = np.array(cam["cameraProjection"]).reshape(4, 4)
+        w_img, h_img = cam["renderProductResolution"]
+
+        fx = P[0, 0] * w_img / 2.0
+        fy = P[1, 1] * h_img / 2.0
+        cx = w_img / 2.0
+        cy = h_img / 2.0
+
+        V_3x3 = V[:3, :3]
+        V_t = V[3, :3]  # translation in last row (row-vector convention)
+        V_inv = np.linalg.inv(V)
+
+        # --- Process each object ---
+        boxes3d = []
+        boxes2d = []
+        categories = []
+        category_certain = []
+
+        for sem_id_str, prim_path in mapping.items():
+            sem_id = int(sem_id_str)
+
+            # Skip non-object entries
+            if sem_id <= 1:
+                continue
+            if "collision_box" in prim_path:
+                continue
+            if not prim_path.startswith("/World/objects/"):
+                continue
+
+            # Extract asset name and scene_data key
+            path_parts = prim_path.split("/")
+            if len(path_parts) < 4:
+                continue
+            asset_name = path_parts[3]  # e.g. "gso_ASICS_GEL..."
+            obj_name = asset_name[4:] if asset_name.startswith("gso_") else asset_name
+
+            # Object transform from scene data
+            if obj_name not in scene_data.get("objects", {}):
+                continue
+            obj_data = scene_data["objects"][obj_name]
+            M = np.array(obj_data["transform_matrix_world"])  # 4x4
+
+            # --- Mask ---
+            obj_mask = mask == sem_id
+            ys, xs = np.where(obj_mask)
+            n_pixels = len(ys)
+            if n_pixels < min_mask_pixels:
+                continue
+
+            # 2D bbox from mask
+            x1, y1, x2, y2 = int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())
+
+            # --- Depth at mask pixels ---
+            d_vals = depth[ys, xs]
+            valid = np.isfinite(d_vals) & (d_vals > 0)
+            if np.sum(valid) < 10:
+                continue
+
+            px = xs[valid].astype(np.float64)
+            py = ys[valid].astype(np.float64)
+            d = d_vals[valid].astype(np.float64)
+
+            # --- Unproject to OpenGL camera space ---
+            X_gl = (px - cx) * d / fx
+            Y_gl = -(py - cy) * d / fy
+            Z_gl = -d
+            pts_cam_gl = np.stack([X_gl, Y_gl, Z_gl], axis=-1)  # (N, 3)
+
+            # --- Camera -> World (row-vector: p_cam = p_world @ V) ---
+            pts_cam_hom = np.hstack([pts_cam_gl, np.ones((len(pts_cam_gl), 1))])
+            pts_world = (pts_cam_hom @ V_inv)[:, :3]
+
+            # --- World -> Scaled local ---
+            # M is row-vector: p_world = p_scaled_local @ R_pure + t
+            # where M_3x3 = diag(scale) @ R_pure, scale = row norms
+            M_3x3 = M[:3, :3]
+            t_obj = M[3, :3]
+
+            row_norms = np.linalg.norm(M_3x3, axis=1)
+            R_pure = M_3x3 / row_norms[:, None]
+
+            # p_scaled = (p_world - t) @ R_pure^T
+            pts_scaled = (pts_world - t_obj) @ R_pure.T
+
+            # --- AABB in scaled local space -> metric dimensions ---
+            aabb_min = pts_scaled.min(axis=0)
+            aabb_max = pts_scaled.max(axis=0)
+            extents = aabb_max - aabb_min
+            w_box, h_box, l_box = extents[0], extents[1], extents[2]
+
+            # Skip degenerate boxes
+            if w_box < 1e-6 or h_box < 1e-6 or l_box < 1e-6:
+                continue
+
+            # --- Center in OpenCV camera space ---
+            center_scaled = (aabb_min + aabb_max) / 2.0
+            center_world = center_scaled @ R_pure + t_obj  # row-vector
+            center_cam_gl = center_world @ V_3x3 + V_t  # row-vector
+            center_cam_cv = np.array(
+                [center_cam_gl[0], -center_cam_gl[1], -center_cam_gl[2]]
+            )
+
+            # --- Rotation: box local -> OpenCV camera (column-vector) ---
+            # Chain: scaled_local --(R_pure^T)--> world --(V_3x3^T)--> cam_gl --(F)--> cam_cv
+            R_box_to_cam_cv = _F @ V_3x3.T @ R_pure.T
+            quat = rotation_matrix_to_quaternion(R_box_to_cam_cv)
+
+            # --- Category from Qwen ---
+            if asset_name in qwen:
+                cat, certain = qwen[asset_name]
+            else:
+                cat, certain = "unknown", False
+
+            # --- Assemble box3d ---
+            box3d = [
+                float(center_cam_cv[0]),
+                float(center_cam_cv[1]),
+                float(center_cam_cv[2]),
+                float(w_box),
+                float(h_box),
+                float(l_box),
+                float(quat[0]),
+                float(quat[1]),
+                float(quat[2]),
+                float(quat[3]),
+            ]
+
+            boxes3d.append([{"box3d": box3d}])
+            boxes2d.append([float(x1), float(y1), float(x2), float(y2)])
+            categories.append(cat)
+            category_certain.append(certain)
+
+        if not boxes3d:
+            return {"status": "no_objects", "stem": stem}
+
+        result = {
+            "image_id": stem,
+            "boxes3d": boxes3d,
+            "boxes2d": boxes2d,
+            "categories": categories,
+            "category_certain": category_certain,
+            "num_candidates": [1] * len(boxes3d),
+        }
+
+        # Atomic write: write to .tmp then rename
+        tmp_path = out_path + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(result, f, indent=2)
+        os.rename(tmp_path, out_path)
+
+        return {"status": "ok", "stem": stem, "n_objects": len(boxes3d)}
+
+    except Exception as e:
+        return {"status": "error", "stem": stem, "error": str(e)}
+
+
+def discover_stems(base_dir):
+    """Discover all image stems from the masks directory."""
+    masks_dir = os.path.join(base_dir, "masks", "gso")
+    stems = []
+    for fname in os.listdir(masks_dir):
+        if fname.endswith(".png"):
+            stems.append(fname[:-4])  # strip .png
+    stems.sort()
+    return stems
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert FoundationPose GSO to 3D bbox format"
+    )
+    parser.add_argument(
+        "--base_dir",
+        required=True,
+        help="Base directory of FoundationPose extracted data",
+    )
+    parser.add_argument(
+        "--output_dir",
+        required=True,
+        help="Output directory for step30_result JSON files",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=16,
+        help="Number of parallel workers",
+    )
+    parser.add_argument(
+        "--min_mask_pixels",
+        type=int,
+        default=100,
+        help="Minimum mask pixels to process an object",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Process only first N images (0 = all, for testing)",
+    )
+    parser.add_argument(
+        "--qwen_classifications",
+        default=None,
+        help=(
+            "Path to gso_qwen_classifications_v2.json. "
+            "If omitted, falls back to "
+            "{base_dir}/qwen_classifications_v2/gso_qwen_classifications_v2.json "
+            "and then to the JSON shipped next to this script."
+        ),
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    logger.info("Discovering image stems from masks directory...")
+    stems = discover_stems(args.base_dir)
+    logger.info(f"Found {len(stems)} images")
+
+    if args.limit > 0:
+        stems = stems[: args.limit]
+        logger.info(f"Limited to {len(stems)} images")
+
+    t0 = time.time()
+
+    # Counters
+    stats = {"ok": 0, "skipped": 0, "no_objects": 0, "error": 0, "missing_file": 0, "no_scene_data": 0}
+    total_objects = 0
+    log_interval = 5000
+
+    if args.workers <= 1:
+        # Single-process mode (easier to debug)
+        init_worker(args.base_dir, args.output_dir, args.min_mask_pixels, args.qwen_classifications)
+        for i, stem in enumerate(stems):
+            result = process_image(stem)
+            status = result["status"]
+            stats[status] = stats.get(status, 0) + 1
+            if status == "ok":
+                total_objects += result["n_objects"]
+            elif status == "error":
+                logger.warning(f"Error on {stem}: {result['error']}")
+            if (i + 1) % log_interval == 0:
+                elapsed = time.time() - t0
+                rate = (i + 1) / elapsed
+                logger.info(
+                    f"Progress: {i+1}/{len(stems)} ({rate:.0f} img/s) "
+                    f"ok={stats['ok']} skip={stats['skipped']} "
+                    f"no_obj={stats['no_objects']} err={stats['error']}"
+                )
+    else:
+        with Pool(
+            args.workers,
+            initializer=init_worker,
+            initargs=(args.base_dir, args.output_dir, args.min_mask_pixels, args.qwen_classifications),
+        ) as pool:
+            for i, result in enumerate(
+                pool.imap_unordered(process_image, stems, chunksize=64)
+            ):
+                status = result["status"]
+                stats[status] = stats.get(status, 0) + 1
+                if status == "ok":
+                    total_objects += result["n_objects"]
+                elif status == "error":
+                    logger.warning(f"Error on {result['stem']}: {result['error']}")
+                if (i + 1) % log_interval == 0:
+                    elapsed = time.time() - t0
+                    rate = (i + 1) / elapsed
+                    logger.info(
+                        f"Progress: {i+1}/{len(stems)} ({rate:.0f} img/s) "
+                        f"ok={stats['ok']} skip={stats['skipped']} "
+                        f"no_obj={stats['no_objects']} err={stats['error']}"
+                    )
+
+    elapsed = time.time() - t0
+    logger.info("=" * 60)
+    logger.info(f"Done in {elapsed:.1f}s ({len(stems)/elapsed:.0f} img/s)")
+    logger.info(f"  OK:            {stats['ok']}")
+    logger.info(f"  Skipped:       {stats['skipped']}")
+    logger.info(f"  No objects:    {stats['no_objects']}")
+    logger.info(f"  Missing file:  {stats['missing_file']}")
+    logger.info(f"  No scene data: {stats['no_scene_data']}")
+    logger.info(f"  Errors:        {stats['error']}")
+    logger.info(f"  Total objects: {total_objects}")
+    if stats["ok"] > 0:
+        logger.info(f"  Avg obj/image: {total_objects / stats['ok']:.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_prep/foundationpose/extract_foundationpose.py
+++ b/scripts/data_prep/foundationpose/extract_foundationpose.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+Script to extract FoundationPose dataset zip files into a comprehensive structured format.
+"""
+
+import os
+import zipfile
+import argparse
+import json
+import shutil
+from pathlib import Path
+from tqdm import tqdm
+import multiprocessing as mp
+from functools import partial
+import re
+
+
+def create_directory_structure(output_dir, dataset_name):
+    """Create the complete directory structure for the dataset."""
+    base_dirs = [
+        f"images/{dataset_name}",
+        f"masks/{dataset_name}",
+        f"depth/{dataset_name}",
+        f"camera_params/{dataset_name}",
+        f"annotations/instance_mappings/{dataset_name}",
+        f"annotations/bounding_box_paths/{dataset_name}",
+        f"scene_data/{dataset_name}",
+        f"metadata/{dataset_name}",
+        f"bounding_boxes/{dataset_name}/loose",
+    ]
+
+    # GSO-specific directories
+    if dataset_name == "gso":
+        base_dirs.extend([
+            f"occlusion/{dataset_name}",
+            f"bounding_boxes/{dataset_name}/tight",
+        ])
+
+    for dir_path in base_dirs:
+        (Path(output_dir) / dir_path).mkdir(parents=True, exist_ok=True)
+
+
+def extract_and_organize_zip(args):
+    """
+    Extract a single zip file and organize into structured format.
+
+    Args:
+        args: Tuple of (zip_path, output_dir, dataset_name)
+    """
+    zip_path, output_dir, dataset_name = args
+
+    try:
+        zip_name = Path(zip_path).stem
+
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            # Get all file paths in the zip
+            file_list = zip_ref.namelist()
+
+            # Organize files by type
+            organized_files = organize_file_paths(file_list, zip_name, dataset_name)
+
+            # Extract each file to its proper location
+            for file_info in organized_files:
+                extract_file_to_location(zip_ref, file_info, output_dir)
+
+        return True, zip_path
+
+    except Exception as e:
+        return False, f"{zip_path}: {str(e)}"
+
+
+def organize_file_paths(file_list, zip_name, dataset_name):
+    """Organize file paths by data type and generate target paths."""
+    organized = []
+
+    for file_path in file_list:
+        if file_path.endswith('/'):
+            continue  # Skip directories
+
+        # Parse the file path structure
+        parts = file_path.split('/')
+        if len(parts) < 2:
+            continue
+
+        if dataset_name == "gso":
+            # GSO structure: object_id/scene_xxxx/scene-hash/[RenderProduct_xxx/]file
+            object_id = parts[0]
+            if len(parts) >= 3 and parts[1].startswith('scene_'):
+                scene_num = parts[1]
+                scene_hash = parts[2] if len(parts) > 2 else ""
+
+                # Generate base name
+                base_name = f"{object_id}_{scene_num}"
+
+                # Handle files in RenderProduct folders
+                if len(parts) >= 5 and parts[3].startswith('RenderProduct'):
+                    camera_id = 0 if parts[3] == "RenderProduct_Replicator" else 1
+                    full_name = f"{base_name}_cam_{camera_id}"
+
+                    file_type = parts[4]  # e.g., 'rgb', 'depth', etc.
+                    filename = parts[5] if len(parts) > 5 else ""
+
+                    target_info = get_target_path_info(file_type, filename, full_name, dataset_name)
+                    if target_info:
+                        organized.append({
+                            'source_path': file_path,
+                            'target_path': target_info['path'],
+                            'target_dir': target_info['dir']
+                        })
+
+                # Handle scene-level files
+                elif len(parts) >= 3:
+                    filename = parts[-1]
+                    if filename == 'states.json':
+                        organized.append({
+                            'source_path': file_path,
+                            'target_path': f"scene_data/{dataset_name}/{base_name}_states.json",
+                            'target_dir': 'scene_data'
+                        })
+                    elif filename == 'scene.usd':
+                        organized.append({
+                            'source_path': file_path,
+                            'target_path': f"scene_data/{dataset_name}/{base_name}_scene.usd",
+                            'target_dir': 'scene_data'
+                        })
+                    elif filename == 'metadata.txt':
+                        organized.append({
+                            'source_path': file_path,
+                            'target_path': f"metadata/{dataset_name}/{base_name}_{scene_hash}_metadata.txt",
+                            'target_dir': 'metadata'
+                        })
+                    elif filename == 'render_stamp.yaml':
+                        organized.append({
+                            'source_path': file_path,
+                            'target_path': f"metadata/{dataset_name}/{base_name}_{scene_hash}_render_stamp.yaml",
+                            'target_dir': 'metadata'
+                        })
+
+        else:  # objaverse_path_tracing
+            # Objaverse structure: zip_id/object_id/[scene-hash/][RenderProduct_xxx/]file
+            zip_id = parts[0]
+            if len(parts) >= 2:
+                object_id = parts[1]
+
+                # Check for drop_objects.yaml at object level
+                if len(parts) == 3 and parts[2] == 'drop_objects.yaml':
+                    organized.append({
+                        'source_path': file_path,
+                        'target_path': f"metadata/{dataset_name}/{zip_id}_{object_id}_drop_objects.yaml",
+                        'target_dir': 'metadata'
+                    })
+                    continue
+
+                if len(parts) >= 4 and parts[2].startswith('scene-'):
+                    scene_hash = parts[2]
+                    base_name = f"{zip_id}_{object_id}_{scene_hash}"
+
+                    # Handle files in RenderProduct folders
+                    if len(parts) >= 6 and parts[3].startswith('RenderProduct'):
+                        camera_id = 0 if parts[3] == "RenderProduct_Replicator" else 1
+                        full_name = f"{base_name}_cam_{camera_id}"
+
+                        file_type = parts[4]
+                        filename = parts[5] if len(parts) > 5 else ""
+
+                        target_info = get_target_path_info(file_type, filename, full_name, dataset_name)
+                        if target_info:
+                            organized.append({
+                                'source_path': file_path,
+                                'target_path': target_info['path'],
+                                'target_dir': target_info['dir']
+                            })
+
+                    # Handle scene-level files
+                    elif len(parts) >= 4:
+                        filename = parts[-1]
+                        if filename == 'metadata.txt':
+                            organized.append({
+                                'source_path': file_path,
+                                'target_path': f"metadata/{dataset_name}/{base_name}_metadata.txt",
+                                'target_dir': 'metadata'
+                            })
+                        elif filename == 'render_stamp.yaml':
+                            organized.append({
+                                'source_path': file_path,
+                                'target_path': f"metadata/{dataset_name}/{base_name}_render_stamp.yaml",
+                                'target_dir': 'metadata'
+                            })
+                        elif filename == 'scene.usd':
+                            organized.append({
+                                'source_path': file_path,
+                                'target_path': f"scene_data/{dataset_name}/{base_name}_scene.usd",
+                                'target_dir': 'scene_data'
+                            })
+
+    return organized
+
+
+def get_target_path_info(file_type, filename, base_name, dataset_name):
+    """Get target path information based on file type."""
+
+    if file_type == 'rgb' and filename.endswith('.png'):
+        return {
+            'path': f"images/{dataset_name}/{base_name}.png",
+            'dir': 'images'
+        }
+    elif file_type == 'distance_to_image_plane' and filename.endswith('.npy'):
+        return {
+            'path': f"depth/{dataset_name}/{base_name}.npy",
+            'dir': 'depth'
+        }
+    elif file_type == 'instance_segmentation':
+        if filename.endswith('.png'):
+            return {
+                'path': f"masks/{dataset_name}/{base_name}.png",
+                'dir': 'masks'
+            }
+        elif 'mapping' in filename and filename.endswith('.json'):
+            suffix = '_semantics' if 'semantics' in filename else '_mapping'
+            return {
+                'path': f"annotations/instance_mappings/{dataset_name}/{base_name}{suffix}.json",
+                'dir': 'annotations'
+            }
+    elif file_type == 'camera_params' and filename.endswith('.json'):
+        return {
+            'path': f"camera_params/{dataset_name}/{base_name}.json",
+            'dir': 'camera_params'
+        }
+    elif file_type == 'occlusion' and filename.endswith('.npy') and dataset_name == 'gso':
+        return {
+            'path': f"occlusion/{dataset_name}/{base_name}.npy",
+            'dir': 'occlusion'
+        }
+    elif file_type == 'bounding_box_2d_loose':
+        if filename.endswith('.npy'):
+            return {
+                'path': f"bounding_boxes/{dataset_name}/loose/{base_name}.npy",
+                'dir': 'bounding_boxes'
+            }
+        elif 'labels' in filename and filename.endswith('.json'):
+            return {
+                'path': f"annotations/bounding_box_paths/{dataset_name}/{base_name}_labels.json",
+                'dir': 'annotations'
+            }
+        elif 'prim_paths' in filename and filename.endswith('.json'):
+            return {
+                'path': f"annotations/bounding_box_paths/{dataset_name}/{base_name}_paths.json",
+                'dir': 'annotations'
+            }
+    elif file_type == 'bounding_box_2d_tight' and dataset_name == 'gso':
+        if filename.endswith('.npy'):
+            return {
+                'path': f"bounding_boxes/{dataset_name}/tight/{base_name}.npy",
+                'dir': 'bounding_boxes'
+            }
+        elif 'labels' in filename and filename.endswith('.json'):
+            return {
+                'path': f"annotations/bounding_box_paths/{dataset_name}/{base_name}_tight_labels.json",
+                'dir': 'annotations'
+            }
+        elif 'prim_paths' in filename and filename.endswith('.json'):
+            return {
+                'path': f"annotations/bounding_box_paths/{dataset_name}/{base_name}_tight_paths.json",
+                'dir': 'annotations'
+            }
+
+    return None
+
+
+def extract_file_to_location(zip_ref, file_info, output_dir):
+    """Extract a file from zip to its target location."""
+    source_path = file_info['source_path']
+    target_path = Path(output_dir) / file_info['target_path']
+
+    # Create target directory if it doesn't exist
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Extract the file
+    with zip_ref.open(source_path) as source_file:
+        with open(target_path, 'wb') as target_file:
+            shutil.copyfileobj(source_file, target_file)
+
+
+def process_dataset(source_dir, output_dir, dataset_type, num_workers=4):
+    """Process all zip files for a dataset type."""
+
+    # Map dataset type to directory name
+    dataset_name = "gso" if dataset_type == "gso" else "objaverse"
+    zip_dir = Path(source_dir) / dataset_type
+
+    # Create directory structure
+    create_directory_structure(output_dir, dataset_name)
+
+    # Get all zip files
+    zip_files = sorted(zip_dir.glob("*.zip"))
+
+    if not zip_files:
+        print(f"No zip files found in {zip_dir}")
+        return
+
+    print(f"Found {len(zip_files)} zip files in {dataset_type}")
+    print(f"Organizing to structured format in: {output_dir}")
+
+    # Prepare arguments for parallel processing
+    args_list = [(str(zip_file), str(output_dir), dataset_name) for zip_file in zip_files]
+
+    # Process with progress bar
+    if num_workers > 1:
+        with mp.Pool(num_workers) as pool:
+            results = list(tqdm(
+                pool.imap(extract_and_organize_zip, args_list),
+                total=len(zip_files),
+                desc=f"Processing {dataset_type}"
+            ))
+    else:
+        results = [extract_and_organize_zip(args) for args in tqdm(args_list, desc=f"Processing {dataset_type}")]
+
+    # Report results
+    successes = sum(1 for success, _ in results if success)
+    failures = [(path, msg) for success, msg in results if not success]
+
+    print(f"\nProcessing complete for {dataset_type}:")
+    print(f"  Success: {successes}/{len(zip_files)}")
+
+    if failures:
+        print(f"  Failed: {len(failures)}")
+        for path, msg in failures:
+            print(f"    - {msg}")
+
+
+def create_dataset_info(output_dir):
+    """Create dataset info file with statistics."""
+    info = {
+        "dataset": "FoundationPose",
+        "description": "6D Object Pose Estimation Dataset",
+        "structure_version": "1.0",
+        "datasets": {
+            "gso": {
+                "source": "Google Scanned Objects",
+                "features": ["rgb", "depth", "2d_bbox_loose", "2d_bbox_tight", "instance_masks", "6d_pose", "occlusion"]
+            },
+            "objaverse": {
+                "source": "Objaverse Path Tracing",
+                "features": ["rgb", "depth", "2d_bbox_loose", "instance_masks", "6d_pose"]
+            }
+        },
+        "image_resolution": [640, 480],
+        "cameras_per_scene": 2
+    }
+
+    info_path = Path(output_dir) / "metadata" / "dataset_info.json"
+    info_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(info_path, 'w') as f:
+        json.dump(info, f, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract FoundationPose dataset into comprehensive structured format"
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        required=True,
+        help="Source directory containing gso and objaverse_path_tracing folders"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output directory for structured data"
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        choices=["gso", "objaverse_path_tracing", "both"],
+        default="both",
+        help="Which dataset to extract"
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Number of parallel workers"
+    )
+
+    args = parser.parse_args()
+
+    source_dir = Path(args.source)
+    output_dir = Path(args.output)
+
+    if not source_dir.exists():
+        print(f"Error: Source directory does not exist: {source_dir}")
+        return
+
+    print(f"FoundationPose Dataset Extraction to Structured Format")
+    print(f"Source: {source_dir}")
+    print(f"Output: {output_dir}")
+    print(f"Workers: {args.workers}")
+    print("-" * 70)
+
+    # Create base output directory
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.dataset in ["gso", "both"]:
+        process_dataset(source_dir, output_dir, "gso", num_workers=args.workers)
+
+    if args.dataset in ["objaverse_path_tracing", "both"]:
+        process_dataset(source_dir, output_dir, "objaverse_path_tracing", num_workers=args.workers)
+
+    # Create dataset info file
+    create_dataset_info(output_dir)
+
+    print(f"\n🎉 All extractions complete!")
+    print(f"📁 Structured dataset available at: {output_dir}")
+    print(f"📊 Dataset info: {output_dir}/metadata/dataset_info.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_prep/foundationpose/gso_qwen_classifications_v2.json
+++ b/scripts/data_prep/foundationpose/gso_qwen_classifications_v2.json
@@ -1,0 +1,11151 @@
+{
+  "dataset": "gso",
+  "status": "completed",
+  "total_assets": 928,
+  "successful": 866,
+  "uncertain": 62,
+  "failed": 0,
+  "elapsed_seconds": 8.291712522506714,
+  "rate_per_second": 11.457223069677772,
+  "max_workers": 64,
+  "num_crops_per_object": 1,
+  "timestamp": 1772020048.3959236,
+  "results": [
+    {
+      "asset_name": "gso_AMBERLIGHT_UP_W",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8395,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a high-top athletic shoe with a blue upper and white sole. It features three parallel stripes on the side, which is a distinctive design element of Adidas footwear. The shoe has a lace-up closure system and appears to be designed for sports or athletic activities. The overall shape and design are consistent with a running or training shoe."
+    },
+    {
+      "asset_name": "gso_ASICS_GELLinksmaster_WhiteCoffeeSand",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8303,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a white athletic shoe with laces, visible stitching, and a brand logo on the tongue. The design, including the shape of the sole and upper, is consistent with a running or training shoe. The perspective is a top-down view, showing the shoe's overall structure and key features like the lacing system and heel counter."
+    },
+    {
+      "asset_name": "gso_ACE_Coffee_Mug_Kristen_16_oz_cup",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8614,
+      "qwen_classification": "mug",
+      "qwen_reasoning": "The object is a cylindrical container with a handle, featuring a red body with white decorative patterns. The shape, handle, and decorative design are characteristic of a mug or cup, commonly used for drinking beverages. The patterns appear to be traditional or ornamental, possibly inspired by East Asian motifs, but this does not change the fundamental classification as a drinking vessel."
+    },
+    {
+      "asset_name": "gso_Asus_X99Deluxe_Motherboard_ATX_LGA2011v3_Socket",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8587,
+      "qwen_classification": "computer ram packaging",
+      "qwen_reasoning": "The object is a rectangular box with printed text and graphics. The visible text includes \"XPG\" and \"DDR4\", which are common branding and specifications for computer memory modules. The box also features images of RAM sticks and technical diagrams, indicating it is packaging for computer hardware. The overall design and content are consistent with product packaging for RAM modules."
+    },
+    {
+      "asset_name": "gso_45oz_RAMEKIN_ASST_DEEP_COLORS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8485,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, shallow dish with a smooth, glossy surface and a raised rim. The color is a uniform green, and the shape suggests it is designed to hold or serve food or liquids. The perspective is top-down, showing the interior and rim clearly. This is consistent with the appearance of a plate or a shallow bowl, commonly used in dining or serving contexts."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_Refrigerator",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8194,
+      "qwen_classification": "cabinet",
+      "qwen_reasoning": "The object is a vertically oriented cabinet with two doors stacked on top of each other. Each door has a light green panel and a light-colored vertical handle. The overall structure suggests it is a piece of furniture designed for storage, likely for a kitchen or bathroom, given its compact, wall-mounted appearance. The style is simple and functional, typical of modern or minimalist cabinetry."
+    },
+    {
+      "asset_name": "gso_Asus_Sabertooth_Z97_MARK_1_Motherboard_ATX_LGA1150_Socket",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8630,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The object appears to be a rectangular box with printed text and images on its surface. The visible text includes \"Z97\" and \"MOTHERBOARD\", which are common terms in computer hardware. The box also features images of circuit boards and other electronic components, which are typical for packaging computer motherboards. The overall design and labeling strongly suggest it is a product box for a computer motherboard."
+    },
+    {
+      "asset_name": "gso_Asus_80211ac_DualBand_Gigabit_Wireless_Router_RTAC68R",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8541,
+      "qwen_classification": "electronics packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and graphics. The visible text includes \"FAST\" and \"Hydro-AC1200 Dual Band Dual Mode Router\", which clearly identifies it as packaging for a wireless router. The box has typical features of consumer electronics packaging, including product specifications, diagrams, and branding. The perspective is a three-quarter view showing the top and side panels."
+    },
+    {
+      "asset_name": "gso_AllergenFree_JarroDophilus",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8303,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a cap, featuring a label with yellow and green sections. The shape, cap, and labeling are characteristic of a pharmaceutical or dietary supplement container. The label likely contains dosage instructions, ingredients, and other regulatory information, which is standard for such products. The bottle appears to be lying on its side, but its form is clearly identifiable as a medicine or supplement bottle."
+    },
+    {
+      "asset_name": "gso_ASICS_GELResolution_5_Flash_YellowBlackSilver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8185,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It features a sleek, modern design with a combination of black, yellow, and white colors. The visible lacing system, the shape of the sole, and the overall construction suggest it is designed for sports or athletic activities. The bright yellow accents and the streamlined silhouette are characteristic of performance footwear, likely for activities such as running or training."
+    },
+    {
+      "asset_name": "gso_ASICS_GELDirt_Dog_4_SunFlameBlack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8161,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has a curved, elongated shape with a distinct sole and upper structure. The coloration is primarily orange with white and red accents, which is typical of athletic footwear. The visible stitching and layered design suggest it is a shoe, likely a sneaker or running shoe, given the style and color scheme. The perspective appears to be a side view, showing the profile of the shoe's body and sole."
+    },
+    {
+      "asset_name": "gso_Android_Figure_Orange",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8548,
+      "qwen_classification": "android mascot",
+      "qwen_reasoning": "The object is a stylized, orange-colored robot with a rounded head, two antennae on top, and a segmented body. It has a distinct design with a blue stripe around the waist and two arms and legs. This is the well-known mascot for the Android operating system, which is a mobile operating system developed by Google. The object is clearly identifiable as the Android robot logo, often used to represent the Android platform."
+    },
+    {
+      "asset_name": "gso_ASICS_GEL1140V_WhiteBlackSilver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8312,
+      "qwen_classification": "sports shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a white upper with black and gray accents, including a distinctive logo pattern on the side. The shoe has laces, a padded collar, and a sole with a yellowish-brown outsole, which is typical for indoor court sports like volleyball or badminton. The design and construction suggest it is a performance athletic shoe, likely for court sports."
+    },
+    {
+      "asset_name": "gso_BUNNY_RACER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8953,
+      "qwen_classification": "skateboard",
+      "qwen_reasoning": "The object shown is a close-up view of a skateboard. It features a grayish, curved deck (the main board) and bright green wheels attached to it. The perspective is angled, showing part of the deck and two wheels on one side, with a third wheel partially visible on the other side. The shape and components are characteristic of a skateboard, which is a wheeled board used for riding and performing tricks."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_Swing",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8722,
+      "qwen_classification": "wooden chair",
+      "qwen_reasoning": "The object is a small, stylized chair made of wood, with a slatted back and seat. The design is simple and blocky, suggesting it might be a miniature or toy version of a chair, possibly for decorative or play purposes. The wood grain texture and color are consistent throughout, and the construction appears to be made of multiple slats joined together. The overall shape is compact and functional, resembling a basic wooden chair."
+    },
+    {
+      "asset_name": "gso_Asus_M5A99FX_PRO_R20_Motherboard_ATX_Socket_AM3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8631,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The object is a product box for a computer motherboard. The branding \"ASUS\" is clearly visible, along with the model number \"M5A99FX PRO R2.0\". The box features typical packaging elements for computer hardware, including logos, certification badges, and product imagery. The text and design are consistent with motherboard packaging from the late 2000s/early 2010s."
+    },
+    {
+      "asset_name": "gso_Arm_Hammer_Diaper_Pail_Refills_12_Pack_MFWkmoweejt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8558,
+      "qwen_classification": "diaper pail refill bag packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and text visible. The prominent text \"DIAPER PAIL REFILL BAGS\" and the recognizable Arm & Hammer logo indicate that this is packaging for disposable bags intended to be used in a diaper pail. The design includes illustrations of diaper pails and bags, reinforcing its purpose. The box is clearly a commercial product package for a household cleaning or baby care item."
+    },
+    {
+      "asset_name": "gso_ASICS_HyperRocketgirl_SP_5_WhiteMalibu_BlueBlack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8194,
+      "qwen_classification": "soccer cleat",
+      "qwen_reasoning": "The object shown is a close-up of the sole of a shoe, specifically a soccer cleat. Key features include the black rubber outsole with multiple conical studs (cleats) designed for traction on grass fields, and the white upper material with blue accents. The shape and design are characteristic of athletic footwear used in soccer. The view is from the bottom, focusing on the sole and studs, which are essential for performance on turf."
+    },
+    {
+      "asset_name": "gso_ASICS_GELTour_Lyte_WhiteOrchidSilver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8359,
+      "qwen_classification": "athletic shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a light beige or cream-colored upper with pink accents on the heel collar, tongue, and toe cap. The shoe features laces, a padded collar, and a visible sole structure, all characteristic of a sneaker or athletic shoe designed for casual wear or sports. The design suggests it is likely a women's or unisex athletic shoe, given the color scheme and styling."
+    },
+    {
+      "asset_name": "gso_BIA_Porcelain_Ramekin_With_Glazed_Rim_35_45_oz_cup",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8298,
+      "qwen_classification": "ramekin",
+      "qwen_reasoning": "The object is a small, round, white ceramic or porcelain dish with vertical fluting on its exterior. It has a shallow, wide bowl shape and appears to be designed for serving individual portions, such as sauces, soups, or desserts. This specific design is characteristic of a ramekin, commonly used in cooking and baking. The fluted sides are a typical decorative and functional feature of ramekins, often used to enhance presentation and provide grip."
+    },
+    {
+      "asset_name": "gso_BABY_CAR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8669,
+      "qwen_classification": "toy robot",
+      "qwen_reasoning": "The object appears to be a small, colorful robotic toy. It has a distinct shape with a green upper section, a yellow lower section, and white rounded appendages on the sides. The design is cartoonish and resembles a robot or a toy vehicle, possibly intended for children. The segmented view suggests it might be a toy robot with wheels or rollers on the sides for movement. The overall appearance is consistent with a toy robot designed for educational or entertainment purposes."
+    },
+    {
+      "asset_name": "gso_Asus_Z87PRO_Motherboard_ATX_LGA1150_Socket",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8541,
+      "qwen_classification": "motherboard box",
+      "qwen_reasoning": "The object is a product box, specifically for a motherboard. The visible text \"Z87-PRO\" and the \"ASUS\" logo are clear indicators. ASUS is a well-known manufacturer of computer hardware, and \"Z87-PRO\" is a specific model name for an Intel Z87 chipset motherboard. The design, with its graphics and layout, is typical of computer component packaging. The object is not a physical motherboard but its retail packaging."
+    },
+    {
+      "asset_name": "gso_ASICS_GELBlur33_20_GS_BlackWhiteSafety_Orange",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8112,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is the sole of a shoe, identifiable by its distinct tread pattern, curved shape, and layered color design (white, gray, and orange). The tread pattern is typical of athletic footwear designed for grip and durability. The curved shape suggests it is from a shoe meant for human feet, likely a running or training shoe. The colors and design are common in modern athletic footwear. There are no other objects or context to suggest it is anything other than a shoe sole."
+    },
+    {
+      "asset_name": "gso_ASICS_GELChallenger_9_Royal_BlueWhiteBlack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8011,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole of a shoe. Key features include a dark-colored (likely black) rubber outsole with a complex tread pattern, blue accent lines or stitching along the edges, and a visible midsole section with a grayish color. The shape and design are consistent with athletic footwear, specifically designed for grip and support during physical activity. The segmented view focuses on the bottom portion, which is typical for showcasing the sole's design and functionality."
+    },
+    {
+      "asset_name": "gso_Azure_Snake_Tieks_Leather_Snake_Print_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8168,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a single shoe, viewed from a side angle. It has a distinct sole with a bright turquoise color, a visible upper part with what looks like a patterned or textured material, and a strap or closure mechanism near the top. The overall shape and features are consistent with a casual slip-on shoe, possibly a loafer or a mule-style shoe. The segmented view isolates the shoe from its surroundings, confirming it is the primary object of interest."
+    },
+    {
+      "asset_name": "gso_3M_Vinyl_Tape_Green_1_x_36_yd",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8451,
+      "qwen_classification": "tape roll",
+      "qwen_reasoning": "The object is a roll of tape, characterized by its cylindrical shape with a visible adhesive side and a core. The green color and the visible branding (\"3M\") on the inner core indicate it is likely a specific type of industrial or utility tape, such as electrical tape or painter's tape. The texture appears smooth and slightly glossy, consistent with plastic or vinyl tape materials. The object is clearly segmented from the background, and its form is unmistakably that of a tape roll."
+    },
+    {
+      "asset_name": "gso_5_HTP",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8477,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that clearly displays \"5-HTP\" in large white letters on a blue background. The brand name \"Jarrow Formulas\" is also visible on the label. This is a common presentation for dietary supplements, specifically 5-HTP (5-Hydroxytryptophan), which is a precursor to serotonin and often sold as a supplement for mood support. The bottle shape, cap, and labeling are consistent with standard supplement containers."
+    },
+    {
+      "asset_name": "gso_ASICS_GELLinksmaster_WhiteRasberryGunmetal",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8196,
+      "qwen_classification": "soccer cleat",
+      "qwen_reasoning": "The object is a single athletic shoe, likely a soccer cleat, based on its design. It features a black and white color scheme with red accents. The most telling feature is the presence of multiple studs or cleats on the sole, which are designed for traction on grass or turf surfaces. The shape, lacing system, and overall construction are consistent with footwear used in soccer or similar sports. The object is shown from a side angle, highlighting the stud pattern and upper structure."
+    },
+    {
+      "asset_name": "gso_BIRD_RATTLE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8473,
+      "qwen_classification": "baby rattle",
+      "qwen_reasoning": "The object appears to be a baby rattle. It has a circular metal or plastic ring with a red and yellow ball inside, which is typical for rattles to create sound when shaken. Attached to the ring are two fabric elements: a green star-shaped piece on one side and a red polka-dotted bow on the other. These decorative elements are common in baby toys designed to be visually stimulating and easy to grasp. The overall design is consistent with a classic baby rattle."
+    },
+    {
+      "asset_name": "gso_Android_Figure_Chrome",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8507,
+      "qwen_classification": "baby bottle",
+      "qwen_reasoning": "The object appears to be a light blue, rounded container with a handle on the side and a spout or nozzle at the bottom. The shape and features are consistent with a baby bottle or a small feeding bottle, commonly used for infants. The handle is ergonomically shaped for holding, and the spout is designed for controlled liquid flow. The material appears to be plastic, typical for such items. The cropped view shows only a portion of the bottle, but the key identifying features are present."
+    },
+    {
+      "asset_name": "gso_ASICS_GELAce_Pro_Pearl_WhitePink",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8347,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a shoe with a distinctive design. It has a sleek, aerodynamic shape typical of athletic footwear. The color scheme is primarily white with prominent pink accents, including a large pink logo or design element on the side. The overall form, including the visible sole and upper structure, suggests it is designed for performance, likely for running or track and field. The branding and style are consistent with modern athletic shoes, particularly those from brands like Asics, which often feature such colorways and logos."
+    },
+    {
+      "asset_name": "gso_50_BLOCKS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8109,
+      "qwen_classification": "wooden toy blocks",
+      "qwen_reasoning": "The object appears to be a set of wooden blocks or building pieces, possibly part of a children's toy. The visible parts include light-colored wooden blocks with some colored accents (red, blue, green) on top or attached to them. The arrangement suggests interlocking or stacking pieces, which is common in construction toys. The perspective is a close-up, angled view, showing the blocks in a staggered or assembled configuration. The white background indicates the object has been cropped and isolated for focus."
+    },
+    {
+      "asset_name": "gso_Avengers_Thor_PLlrpYniaeB",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8779,
+      "qwen_classification": "storage bin",
+      "qwen_reasoning": "The object appears to be a rectangular container with open sides and a hinged or foldable lid on one end. The design suggests it is meant for storage or transport, possibly for items like tools, parts, or other small goods. The construction looks like it could be made of plastic or metal, with reinforced edges and a sturdy structure. This type of container is commonly known as a 'tool box' or 'storage bin', and its shape and features are consistent with industrial or workshop storage containers."
+    },
+    {
+      "asset_name": "gso_BUILD_A_ZOO",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8346,
+      "qwen_classification": "shape sorter toy",
+      "qwen_reasoning": "The object appears to be a children's toy, specifically a shape sorter or a puzzle with multiple colored compartments. It has a grid-like structure with different colored sections (yellow, red, green, blue, white) and contains various small, colorful shapes (like a red bird-like figure, a blue shape, a yellow shape, and a white egg-like shape) that fit into the corresponding slots. This design is typical of educational toys designed to develop fine motor skills and shape recognition in young children."
+    },
+    {
+      "asset_name": "gso_11pro_SL_TRX_FG",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8114,
+      "qwen_classification": "soccer cleat sole",
+      "qwen_reasoning": "The object is a bright neon green, curved piece with multiple black, conical protrusions on its surface. These protrusions are characteristic of cleats or studs designed for traction. The shape and texture suggest it is the sole or bottom part of a sports shoe, specifically designed for use on grass or turf fields. The black and white striped pattern visible along the edge further supports this, as it is typical of athletic footwear. This is most likely the sole of a soccer cleat or a similar turf shoe."
+    },
+    {
+      "asset_name": "gso_Asus_Z97IPLUS_Motherboard_Mini_ITX_LGA1150_Socket",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8736,
+      "qwen_classification": "computer case",
+      "qwen_reasoning": "The object is a rectangular box with a glossy, dark blue and black design. It features prominent branding and text, including \"ZOTAC\" and \"ZOTAC ZBOX\" along with a circular logo. The box appears to be packaging for a computer component, likely a mini PC or small form factor computer, given the branding and typical product packaging style for such electronics. The text \"ZBOX\" and \"ZOTAC\" are clearly visible, and the design suggests it's a consumer electronics product box."
+    },
+    {
+      "asset_name": "gso_Adrenaline_GTS_13_Color_WhtObsdianBlckOlmpcSlvr_Size_70",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8163,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The image shows a close-up view of the sole of a shoe. The sole has a distinct tread pattern with multiple circular and star-like indentations, which is typical for athletic or training shoes designed for grip and traction. The color scheme is primarily blue and black with some gray or silver accents. The shape and design suggest it is a sports shoe, likely for activities like running or training. The object is clearly identifiable as a shoe sole, and given the context, it is most likely part of a running or training shoe."
+    },
+    {
+      "asset_name": "gso_BALANCING_CACTUS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8587,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object appears to be a colorful, stylized toy or figurine. It has a green, segmented body resembling a caterpillar or a multi-jointed creature. There are multiple small, rounded appendages in various colors (orange, red, yellow) attached to its body, which could represent limbs or decorative elements. The object also has a light-colored, cylindrical base or handle extending from one end. The overall design is playful and cartoonish, suggesting it is a children's toy rather than a functional or natural object."
+    },
+    {
+      "asset_name": "gso_ASICS_GELLinksmaster_WhiteSilverCarolina_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8212,
+      "qwen_classification": "cleat",
+      "qwen_reasoning": "The object is a white athletic shoe with a visible sole featuring multiple small, conical studs. This type of sole is characteristic of cleats, which are designed for traction on grass or turf surfaces. The shoe has a lace-up closure and a streamlined, performance-oriented design typical of sports footwear. The presence of studs confirms it is not a casual or indoor shoe, but specifically engineered for sports like soccer, football, or field sports played on grass. The light blue accents on the side are a design detail, not a functional feature."
+    },
+    {
+      "asset_name": "gso_Apples_to_Apples_Kids_Edition",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8341,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful graphics. It features the text \"APPLES KIDS 7+\" and an illustration of a smiling green apple. The packaging also includes age recommendations (7-4-10) and a logo that appears to be for \"M&M\" (likely a brand or product line). This is clearly product packaging, specifically for a children's product, likely a snack or toy given the branding and age targeting. The box is shown at an angle, revealing its three-dimensional form."
+    },
+    {
+      "asset_name": "gso_ASICS_GELBlur33_20_GS_Flash_YellowHot_PunchSilver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8172,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole and lower part of a shoe. Key features include a thick, patterned rubber outsole with deep treads for traction, a white midsole, and a bright yellow and pink upper section with visible stitching or design elements. The shape and construction are characteristic of athletic footwear, specifically designed for running or training. The segmented view focuses on the bottom and side of the shoe, excluding the upper body or laces, but the overall structure is unmistakably that of a running shoe."
+    },
+    {
+      "asset_name": "gso_Asus_Z97AR_LGA_1150_Intel_ATX_Motherboard",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8585,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and text visible. The text \"Z97-AR\" and \"5-WAY\" are clearly printed on the box, which are model identifiers commonly used for computer motherboards. The ASUS logo is also visible, which is a well-known manufacturer of computer hardware. The design and text indicate this is packaging for a computer motherboard, specifically an ASUS Z97-AR model. The box is shown from an angled perspective, revealing multiple sides, which is typical for product packaging."
+    },
+    {
+      "asset_name": "gso_BRAILLE_ALPHABET_AZ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8157,
+      "qwen_classification": "alphabet blocks",
+      "qwen_reasoning": "The object consists of multiple light-colored, cube-shaped pieces, each with a different letter or symbol printed on it (e.g., 'X', 'Y', 'U', 'O', 'D', 'P', 'K', 'J', 'C'). These pieces are arranged in a scattered, overlapping manner, suggesting they are individual components that can be assembled or rearranged. This appearance is characteristic of alphabet blocks or letter tiles, commonly used for educational or play purposes. The shapes and markings are consistent with such toys."
+    },
+    {
+      "asset_name": "gso_Asus_Sabertooth_990FX_20_Motherboard_ATX_Socket_AM3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8564,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The image displays a product box with clear text identifying it as an \"ASUS SABERTOOTH 990FX R2.0 MOTHERBOARD\". The branding, model number, and the term \"motherboard\" explicitly identify this as a computer hardware component. The box also features graphics and logos typical of computer hardware packaging, including the ASUS logo and a stylized dragon graphic. This is a standard retail package for a motherboard, which is a printed circuit board that connects and allows communication between various components of a computer."
+    },
+    {
+      "asset_name": "gso_60_CONSTRUCTION_SET",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8322,
+      "qwen_classification": "robotic arm",
+      "qwen_reasoning": "The object appears to be a mechanical or robotic component, possibly a robotic arm or a linkage mechanism. It consists of multiple interconnected parts, including rods, joints, and colored knobs or fasteners (yellow, green, blue, red). The structure suggests it is designed for movement or manipulation, with pivot points and adjustable elements. The overall design resembles a kit or educational toy, such as those used in robotics or engineering education (e.g., LEGO Technic or similar systems). The presence of multiple colored fasteners and modular construction supports this interpretation."
+    },
+    {
+      "asset_name": "gso_ASICS_GEL1140V_WhiteRoyalSilver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 7996,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a portion of a shoe, specifically the side or heel area. It has a curved, contoured shape typical of footwear. The visible materials include white, blue, and a small section of yellow, suggesting a colorful athletic or casual shoe design. The texture and stitching patterns are consistent with synthetic or leather shoe uppers. The cropped view focuses on the lateral side, showing part of the sole or midsole structure. Based on the shape, materials, and color scheme, it is most likely a sports shoe or sneaker."
+    },
+    {
+      "asset_name": "gso_Animal_Planet_Foam_2Headed_Dragon",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 7948,
+      "qwen_classification": "dragon",
+      "qwen_reasoning": "The object in the image is a stylized, blue, reptilian creature with a long tail and a prominent dorsal fin or ridge along its back. Its posture and form suggest it is a fictional or fantasy creature, possibly a dragon or a similar mythical beast. The design is simplified and appears to be from a video game or digital artwork, given the pixelated texture and lack of fine anatomical detail. It does not resemble any real-world animal or object. The object is clearly segmented from the background, and the white areas are not part of the object itself."
+    },
+    {
+      "asset_name": "gso_ALPHABET_AZ_GRADIENT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8083,
+      "qwen_classification": "alphabet blocks",
+      "qwen_reasoning": "The object consists of multiple wooden blocks, each with a single uppercase letter of the alphabet printed on it in various colors. The blocks are arranged in a scattered, overlapping manner, suggesting they are part of an educational toy or puzzle. The visible letters include A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z. This is characteristic of alphabet blocks used for learning letters and spelling."
+    },
+    {
+      "asset_name": "gso_Asus_M5A78LMUSB3_Motherboard_Micro_ATX_Socket_AM3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8781,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The object is a rectangular box with text and graphics on its surface. The visible text includes \"M5A78L-M\" and \"ASUS\", which are model numbers and a brand name commonly associated with computer hardware. The design, including the layout of text, diagrams, and logos, is typical of product packaging for computer components, specifically motherboards. The box appears to be angled, showing multiple sides, which is common in product photography or packaging displays. The presence of technical specifications and branding confirms it is not a generic box but packaging for a specific electronic component."
+    },
+    {
+      "asset_name": "gso_Adrenaline_GTS_13_Color_DrkDenimWhtBachlorBttnSlvr_Size_50_yfK40TNjq0V",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8162,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object appears to be a close-up view of the side of a shoe, specifically focusing on the midsole and outsole area. The visible features include layered cushioning, a textured sole pattern, and what looks like branding or a logo on the side. The color scheme is predominantly blue and gray, with some black accents. The shape and construction are consistent with athletic footwear, particularly running or training shoes, which often feature prominent cushioning and a durable outsole. The cropped view suggests this is a segment from a larger image, but the key identifying features are present to confidently classify it."
+    },
+    {
+      "asset_name": "gso_2_of_Jenga_Classic_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8131,
+      "qwen_classification": "wooden furniture component",
+      "qwen_reasoning": "The object appears to be a wooden structure with a series of parallel, horizontal slats or planks. The arrangement suggests it could be part of a larger item, such as a wooden bench, a decorative panel, or a component of furniture. The visible grain and texture are consistent with wood. The shape is irregular, with a curved or angled front edge and a stepped or layered back, which might indicate it's a section of a larger piece. Without more context or views, it's difficult to determine its exact function, but it is clearly a wooden object with a constructed, layered design."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_Happy_Brother",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8339,
+      "qwen_classification": "toy figure",
+      "qwen_reasoning": "The object appears to be a small, stylized figure, likely a toy or doll, shown from a top-down or overhead perspective. It has a yellow hooded top (possibly a hoodie or jacket) and blue pants. The limbs are visible and appear to be articulated or jointed, suggesting it is a movable toy. The overall shape and proportions are consistent with a child's toy figure, such as a plush doll or action figure. The rendering style is somewhat blocky and low-polygon, which may indicate it is from a video game or 3D model rather than a real-world physical object. However, based on the visible features, it is clearly a toy figure."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_Lamp",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8107,
+      "qwen_classification": "pestle",
+      "qwen_reasoning": "The object has a distinct shape with a rounded top, a long cylindrical body with segmented or beaded texture, and a wider, flared base. This form is characteristic of a pestle, which is a tool used for grinding or crushing substances in a mortar. The segmented middle section suggests it may be designed for grip or ergonomic handling. The color scheme (dark purple top and base, light beige middle) is likely decorative or for identification purposes, but does not affect its functional classification. The object is clearly not a tool for writing, eating, or electronic use, and its shape is too specific to be a generic 'tool' without further context. The segmented middle is a key feature that supports its identification as a pestle, as many pestles have textured or beaded handles for better grip during grinding."
+    },
+    {
+      "asset_name": "gso_Aroma_Stainless_Steel_Milk_Frother_2_Cup",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8850,
+      "qwen_classification": "thermos",
+      "qwen_reasoning": "The object has a cylindrical body with a metallic, stainless steel finish, a black plastic handle on top, and a black lid with a visible sealing mechanism. This design is characteristic of a portable, insulated beverage container. The shape and features suggest it is designed for holding hot or cold drinks, likely for on-the-go use. The lid appears to be a screw-on or snap-on type, common for thermal flasks or travel mugs. The overall form factor is consistent with a thermos or travel mug, but the lid design and handle placement suggest it is more likely a thermos flask rather than a typical travel mug, as thermos flasks often have a more robust, insulated construction and a lid designed for sealing to retain temperature. The object is clearly a container for beverages, specifically designed for thermal insulation."
+    },
+    {
+      "asset_name": "gso_Bifidus_Balance_FOS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8338,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a purple label. The label includes text such as \"Supplement Facts\" and a barcode, which are typical features of dietary supplement containers. The shape and labeling strongly suggest it is a bottle for pills or capsules. The white background is masked, but the object's features are clear enough to identify it confidently."
+    },
+    {
+      "asset_name": "gso_Blackcurrant_Lutein",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8584,
+      "qwen_classification": "protein supplement bottle",
+      "qwen_reasoning": "The object is a cylindrical container with a white cap and a label. The label is predominantly purple and features text that appears to read \"Blackcurrant Protein\" along with an image of blackcurrants. This indicates it is a supplement bottle, likely containing protein powder flavored with blackcurrant. The shape, cap, and labeling are consistent with common dietary supplement packaging."
+    },
+    {
+      "asset_name": "gso_Black_Decker_Stainless_Steel_Toaster_4_Slice",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8678,
+      "qwen_classification": "toaster",
+      "qwen_reasoning": "The object shown is a kitchen appliance with a metallic, silver-colored finish. It has a rectangular body with two slots designed to hold slices of bread, which is characteristic of a toaster. A power cord is visible extending from the side, confirming it is an electrical appliance. The design is modern and sleek, with rounded edges. This is clearly a toaster, specifically a 2-slice model."
+    },
+    {
+      "asset_name": "gso_Beetle_Adventure_Racing_Nintendo_64",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8359,
+      "qwen_classification": "video game cartridge",
+      "qwen_reasoning": "The object is a gray plastic cartridge with a label on the front. The label features colorful artwork, including a yellow vehicle and green foliage, along with text and logos. This design is characteristic of video game cartridges for the Nintendo Game Boy Advance, which were typically gray and had printed labels with game artwork. The shape and size are consistent with a GBA game cartridge, and the visible artwork matches the cover art for the game 'Mario Kart: Double Dash!!'."
+    },
+    {
+      "asset_name": "gso_Beyonc_Life_is_But_a_Dream_DVD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8113,
+      "qwen_classification": "book",
+      "qwen_reasoning": "The object appears to be a dark, rectangular item with a glossy surface, possibly a book or a case. It has a visible spine and what looks like text or imagery on its cover. The object is tilted at an angle, and the lighting creates reflections on its surface. The content on the cover is not clearly legible, but it seems to feature some kind of graphic or text layout. Given its shape and appearance, it is most likely a book or a similar rectangular container."
+    },
+    {
+      "asset_name": "gso_Beta_Glucan",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8452,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a blue and gold label. The label clearly displays the text \"Beta Glucan\" in large, bold letters, indicating it is a dietary supplement or health product. The bottle's shape and labeling are typical for over-the-counter supplements. The label also includes smaller text and a logo, which is common for product packaging. The object is not a container for food, drink, or other consumables, but specifically a supplement bottle."
+    },
+    {
+      "asset_name": "gso_Black_Elderberry_Syrup_54_oz_Gaia_Herbs",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8465,
+      "qwen_classification": "box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed labels and color bands (pink, green, and brown). The design and shape are typical of product packaging, likely for a consumer item such as a box of tissues, snacks, or stationery. The visible text and graphics suggest it is a commercial product package, but the specific contents cannot be determined from the image alone. Given the context and appearance, it is most likely a consumer goods box."
+    },
+    {
+      "asset_name": "gso_COAST_GUARD_BOAT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8554,
+      "qwen_classification": "rubber stamp",
+      "qwen_reasoning": "The object has a distinct shape with a rounded, orange-colored top (handle) and a wider, red-and-beige base. This form factor is characteristic of a rubber stamp, which is typically used for imprinting designs or text onto surfaces. The handle allows for gripping and pressing, while the base contains the inked surface. The colors and design are consistent with common office or craft stamps."
+    },
+    {
+      "asset_name": "gso_BUNNY_RATTLE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8394,
+      "qwen_classification": "teething toy",
+      "qwen_reasoning": "The object appears to be a baby teething toy. It has a soft, rounded ring shape, which is common for teething rings designed to be chewed on by infants. The toy is multi-colored with sections of orange, green, and a light beige or off-white. There are also small, colorful attachments (possibly fabric or plastic pieces) that are often included in teething toys to provide varied textures and sensory stimulation. The overall design is soft, safe-looking, and suitable for a baby's mouth, which strongly suggests it is a teething toy."
+    },
+    {
+      "asset_name": "gso_Canon_Ink_Cartridge_Green_6",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8469,
+      "qwen_classification": "ink cartridge",
+      "qwen_reasoning": "The object is a Canon brand ink cartridge, specifically model number 6, which is green. The packaging clearly displays the Canon logo, the number 6, and the word 'Green'. This is a consumable product for inkjet printers. The visual design, including the color coding and branding, is consistent with Canon's standard ink cartridge packaging."
+    },
+    {
+      "asset_name": "gso_Central_Garden_Flower_Pot_Goo_425",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8670,
+      "qwen_classification": "plant pot",
+      "qwen_reasoning": "The object is a conical, terracotta-colored pot with a flared rim, typical of a small flower pot or plant container. Its shape, material appearance, and rim design are characteristic of ceramic or clay pots used for gardening or indoor plants. The object is shown from a single angled view, but its form is clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Borage_GLA240Gamma_Tocopherol",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8422,
+      "qwen_classification": "pill bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a reddish-brown label. The label has text and a barcode, which is typical for pharmaceutical or dietary supplement containers. The shape is cylindrical with a slightly tapered neck, consistent with pill bottles. The perspective shows the side and back of the bottle, where nutritional or ingredient information is usually printed. The object is clearly a container for pills or capsules, not a beverage or other type of bottle."
+    },
+    {
+      "asset_name": "gso_Balderdash_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8638,
+      "qwen_classification": "video game box",
+      "qwen_reasoning": "The object is a rectangular box with a light blue color scheme. On the front, there is text that appears to read \"Baldur's Gate\" in a stylized font, along with some imagery that includes a character silhouette and what looks like a scene from a game. This is characteristic of a video game box. The design, typography, and imagery are consistent with packaging for a role-playing video game, specifically Baldur's Gate, which is a well-known series. The box has a standard game case shape with visible edges and corners, suggesting it is a physical product."
+    },
+    {
+      "asset_name": "gso_Canon_Pixma_Ink_Cartridge_8_Green",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8727,
+      "qwen_classification": "ink cartridge packaging",
+      "qwen_reasoning": "The object is a product package, specifically for a Canon printer ink cartridge. The red and white packaging with the Canon logo is characteristic of Canon's ink cartridge packaging. The visible text \"PG-810\" and the color indicator (green) suggest it is a cyan ink cartridge. The shape and design are consistent with retail packaging for printer consumables."
+    },
+    {
+      "asset_name": "gso_Black_Forest_Fruit_Snacks_28_Pack_Grape",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8824,
+      "qwen_classification": "snack food box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful graphics and text. The text \"Fruit Snacks\" is clearly visible, along with images of various fruits (like grapes, pineapple, and citrus). The design suggests it is packaging for a food product, specifically a snack item. The box has a typical commercial packaging structure with flaps and printed branding, indicating it is intended for retail sale. The overall appearance is consistent with a snack food box, likely containing individually wrapped fruit-flavored snacks."
+    },
+    {
+      "asset_name": "gso_Baby_Elements_Stacking_Cups",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 7923,
+      "qwen_classification": "toy component",
+      "qwen_reasoning": "The object appears to be a set of nested, colorful plastic tubes or rings, possibly part of a children's toy or a modular construction set. The tubes are stacked in a slightly curved, overlapping arrangement, with visible color bands (yellow, green, blue, orange, red). The shape and material suggest they are designed to be interlocked or connected, which is common in educational or play toys. The curved end of the yellow tube suggests it might be part of a larger structure or designed to be flexible. Given the bright colors and modular design, it is most likely a children's toy component."
+    },
+    {
+      "asset_name": "gso_Big_O_Sponges_Assorted_Cellulose_12_pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8440,
+      "qwen_classification": "sponge",
+      "qwen_reasoning": "The object shown is a rectangular, porous item with a textured surface featuring numerous small holes. This structure is characteristic of a cleaning sponge, commonly used for scrubbing dishes, surfaces, or for personal hygiene. The purple color is typical for many household sponges, though not universal. The segmented view isolates the sponge from its surroundings, confirming it is the primary subject. There are no features suggesting it is any other type of object (e.g., a piece of foam, a toy, or a biological specimen)."
+    },
+    {
+      "asset_name": "gso_Big_Dot_Pink_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8415,
+      "qwen_classification": "sleeping bag",
+      "qwen_reasoning": "The object is a cylindrical item with a pattern of large pink circles on a dark brown background. It appears to be a rolled-up fabric item, possibly a sleeping bag, a mat, or a decorative cushion. The presence of a small blue tag or zipper pull at one end suggests it is a functional item that can be opened or closed. The shape and pattern are consistent with a portable, rolled-up product designed for storage or transport. Given the context and appearance, it is most likely a sleeping bag or a similar rolled-up textile product."
+    },
+    {
+      "asset_name": "gso_Canon_Pixma_Ink_Cartridge_8",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8399,
+      "qwen_classification": "ink cartridge",
+      "qwen_reasoning": "The object is a Canon printer ink cartridge in its original packaging. The red top of the package clearly displays the 'Canon' brand logo. The number '8' is prominently featured on the side, indicating the cartridge model. There is also a small icon showing the color (cyan) and the model number 'PG-8'. This is a standard retail package for a printer consumable item."
+    },
+    {
+      "asset_name": "gso_Black_and_Decker_PBJ2000_FusionBlade_Blender_Jars",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8733,
+      "qwen_classification": "kitchen appliance",
+      "qwen_reasoning": "The image shows a product box with the brand name 'BLACK & DECKER' visible. The box features an image of a small, cylindrical appliance with a black base and a clear or translucent body, which appears to be a blender or a similar kitchen appliance. The text on the box includes '1.7L' and 'AIR', suggesting it's a 1.7-liter capacity appliance, possibly an air fryer or a blender with air technology. The design and branding are consistent with Black & Decker's kitchen appliances."
+    },
+    {
+      "asset_name": "gso_Brother_Ink_Cartridge_Magenta_LC75M",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8357,
+      "qwen_classification": "ink cartridge packaging",
+      "qwen_reasoning": "The object is a product package, specifically for an ink cartridge. The visible text \"LC75M\" and \"XL\" indicates it is a Brother brand ink cartridge (LC-75M is a common model number for Brother printers). The packaging includes branding, product information, and an image of colorful candies, which is likely a design element to appeal to consumers. The shape and structure are typical of retail ink cartridge packaging, with a cardboard or plastic box form."
+    },
+    {
+      "asset_name": "gso_BlueBlack_Nintendo_3DSXL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8551,
+      "qwen_classification": "phone",
+      "qwen_reasoning": "The object shown is a portable electronic device with a rectangular screen, a black casing, and a visible front-facing camera and speaker grille at the top. The device is partially enclosed in a blue protective case or cover that is open, revealing the screen. This design is characteristic of early smartphones, specifically the first-generation iPhone (iPhone 4 or 4S), which had a similar form factor, screen size, and physical layout. The blue case is likely a protective cover or sleeve. The object is clearly identifiable as a smartphone."
+    },
+    {
+      "asset_name": "gso_Breyer_Horse_Of_The_Year_2015",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8146,
+      "qwen_classification": "horse",
+      "qwen_reasoning": "The object in the image is a four-legged animal with a slender body, long neck, and flowing mane, captured mid-motion with its legs extended. The coloration is a light tan or chestnut with white markings on the face and legs, which is typical of many horse breeds. The posture suggests movement, possibly galloping or leaping. The shape, proportions, and features are consistent with a horse, and there are no other plausible interpretations given the clear segmentation and visible anatomy."
+    },
+    {
+      "asset_name": "gso_Chefmate_8_Frypan",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7809,
+      "qwen_classification": "frying pan",
+      "qwen_reasoning": "The object is a cooking pan, specifically a frying pan or skillet. It has a round, shallow bowl shape with a raised rim, a long handle attached to the side, and a metallic, likely non-stick or stainless steel, surface. The pan appears to be damaged or broken, with a large chunk missing from its side, but the core structure and features are clearly identifiable as a frying pan."
+    },
+    {
+      "asset_name": "gso_ClimaCool_Aerate_2_W_Wide",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8428,
+      "qwen_classification": "comb",
+      "qwen_reasoning": "The object appears to be a comb, characterized by its series of parallel, closely spaced teeth. The teeth are pink and have a slightly curved, rounded shape, which is typical for hair combs designed for gentle detangling or styling. The top portion of the comb has a brownish, possibly wooden or plastic, handle or base. The overall structure and design are consistent with a common personal grooming tool used for hair."
+    },
+    {
+      "asset_name": "gso_CoQ10",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8610,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that has text and a barcode. The shape, cap, and labeling are characteristic of a pharmaceutical or supplement bottle. The label appears to contain regulatory or product information, which is typical for such containers. The bottle is lying on its side, but its form is clearly identifiable as a container for pills or capsules."
+    },
+    {
+      "asset_name": "gso_Canon_225226_Ink_Cartridges_BlackColor_Cyan_Magenta_Yellow_6_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8808,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular cardboard box, likely for a product. It has a handle cutout at the top, which is common for retail packaging. There are printed text and graphics on the surface, including what looks like a logo (possibly Canon, given the red and black design elements) and recycling symbols. The box is angled, showing its three-dimensional form. This is typical packaging for consumer electronics, office supplies, or similar products."
+    },
+    {
+      "asset_name": "gso_CAR_CARRIER_TRAIN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 7835,
+      "qwen_classification": "vehicle",
+      "qwen_reasoning": "The object appears to be a stylized, pixelated representation of a vehicle, likely a car or truck. It has a distinct shape with a black upper section (possibly the roof or hood), a red middle section (likely the body), and a blue lower section (possibly the bumper or undercarriage). The overall form suggests a vehicle with a cab and chassis, and the pixelated style indicates it is likely from a video game or digital artwork. The object is not a real-world photograph but a digital rendering."
+    },
+    {
+      "asset_name": "gso_Canon_Pixma_Ink_Cartridge_8_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8668,
+      "qwen_classification": "printer packaging",
+      "qwen_reasoning": "The object is a white, rectangular package with a curved top edge and a hanging hole, typical of retail packaging. The text \"PIXMA\" is visible, which is a well-known brand name for printers by Canon. The design and branding strongly suggest this is packaging for a Canon PIXMA printer or printer-related product (such as ink cartridges or accessories). The shape and features are consistent with product packaging designed for display on store shelves."
+    },
+    {
+      "asset_name": "gso_Brisk_Iced_Tea_Lemon_12_12_fl_oz_355_ml_cans_144_fl_oz_426_lt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8455,
+      "qwen_classification": "beverage case",
+      "qwen_reasoning": "The object is a cardboard box with branding for 'Brisk', which is a well-known brand of iced tea. The box has a colorful design with blue, yellow, and green, and features imagery of lemons and pine trees, suggesting a citrus-flavored iced tea. The text on the box includes 'ICED TEA' and 'LEMON LIME', confirming its contents. The shape and labeling are consistent with a standard beverage case used for retail sale, typically containing multiple individual bottles or cans."
+    },
+    {
+      "asset_name": "gso_Chelsea_BlkHeelPMP_DwxLtZNxLZZ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8390,
+      "qwen_classification": "high-heeled shoe",
+      "qwen_reasoning": "The object shown is a single shoe with a distinct leopard print pattern on its upper surface. It has a pointed toe and a visible heel, suggesting it is a women's high-heeled shoe. The material appears to be a soft fabric or faux leather, and the interior lining is a solid brown color. The shape and design are consistent with a classic pump or stiletto-style shoe, commonly worn for fashion or formal occasions."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Antislip_Surfacing_White_2_x_60",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8460,
+      "qwen_classification": "toilet paper roll",
+      "qwen_reasoning": "The object is a cylindrical roll of white material with a hollow center, consistent with the appearance of a standard toilet paper roll. The texture and form factor are typical of household toilet paper, which is commonly rolled and dispensed from a cardboard core. The white background masking indicates this is a cropped, segmented view focusing solely on the object."
+    },
+    {
+      "asset_name": "gso_California_Navy_Tieks_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8033,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a high-heeled shoe, specifically a pump style. It has a dark brown or black upper, a green insole, and a visible heel. The shape and structure are consistent with women's formal or dress shoes. The view is a side profile, showing the heel and the curve of the shoe's body. The green insole is a distinctive feature, possibly indicating a specific brand or design element. The object is clearly segmented from the background, and the non-white regions represent the shoe itself."
+    },
+    {
+      "asset_name": "gso_Canon_Pixma_Chromalife_100_Magenta_8",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8834,
+      "qwen_classification": "ink cartridge package",
+      "qwen_reasoning": "The object is a product package, specifically for a Canon ink cartridge. The red cardboard flap with the 'Canon' logo is characteristic of Canon's packaging design. The white plastic or cardboard body of the package has a label with color indicators (pink and green) and a small icon resembling an ink cartridge. This is consistent with the packaging for a Canon printer ink cartridge, likely a color cartridge given the color indicators. The object is clearly identifiable as a consumer electronics accessory package."
+    },
+    {
+      "asset_name": "gso_CoQ10_BjTLbuRVt1t",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8508,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a white plastic container with a label that includes a barcode and text. The shape is cylindrical with a slightly tapered top and a wider base, typical of a bottle or jar. The label suggests it contains product information, which is common for pharmaceuticals, supplements, or household chemicals. The overall appearance is consistent with a medicine bottle or supplement container, though the specific contents cannot be determined from the image alone."
+    },
+    {
+      "asset_name": "gso_CLIMACOOL_BOAT_BREEZE_IE6CyqSaDwN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8316,
+      "qwen_classification": "cycling shoe",
+      "qwen_reasoning": "The object appears to be a cycling shoe, specifically the toe and upper part of the shoe. It has a sleek, aerodynamic design typical of performance cycling footwear. The color scheme is predominantly black with blue accents, and there are visible straps or lacing systems that are common in cycling shoes for a secure fit. The shape and contours suggest it is designed for a snug fit around the foot and ankle, which is characteristic of cycling shoes. The white background indicates the object has been cropped and isolated from its original context, but the key features are still clearly visible."
+    },
+    {
+      "asset_name": "gso_Clue_Board_Game_Classic_Edition",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8240,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box, likely for a product. It has a green exterior with colorful graphics on the front, including what looks like a circular logo or emblem and various images that could represent product contents or branding. The perspective is angled, showing the top and one side of the box. The design suggests it is a commercial packaging item, possibly for a snack, toy, or other consumer goods. The white areas are masking, not part of the object."
+    },
+    {
+      "asset_name": "gso_Black_Forest_Fruit_Snacks_Juicy_Filled_Centers_10_pouches_9_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8349,
+      "qwen_classification": "fruit snack box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful graphics. The text \"Fruit Snacks\" is clearly visible, along with images of various fruits (grapes, lemon, apple, cherry). There are also icons indicating nutritional information (e.g., \"100% fruit juice,\" \"low sugar\"). This packaging style and labeling are typical for a commercial food product, specifically a snack item. The box appears to be for a multi-pack of individual fruit snacks, as suggested by the \"10\" on the top corner and the segmented design. The overall appearance is that of a consumer packaged good for fruit-flavored snacks."
+    },
+    {
+      "asset_name": "gso_Black_and_Decker_TR3500SD_2Slice_Toaster",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8559,
+      "qwen_classification": "toaster oven",
+      "qwen_reasoning": "The object has a rectangular, box-like shape with a metallic, brushed finish. It features a power cord with a plug extending from one side, indicating it is an electrical appliance. The bottom has a vented or slatted design, which is common in devices that generate heat. The overall form and features are consistent with a toaster oven or a small countertop convection oven, which are designed for toasting, baking, or heating food. The object lacks visible controls or a door, but the vented base suggests it is a heating appliance. Given the context and appearance, it is most likely a toaster oven or a similar small kitchen appliance."
+    },
+    {
+      "asset_name": "gso_Canon_Pixma_Ink_Cartridge_Cyan_251",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8428,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a white cardboard package with a handle cutout at the top. It features instructional diagrams (likely showing how to use the product) and text, along with a barcode at the bottom. This packaging style is typical for consumer goods, especially small electronic devices, accessories, or medical products. The diagrams suggest it's for a product that requires assembly or specific usage steps. Given the visual evidence, it is most likely a product box, but without more context or visible branding, a more specific classification is not possible."
+    },
+    {
+      "asset_name": "gso_Blue_Jasmine_Includes_Digital_Copy_UltraViolet_DVD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8336,
+      "qwen_classification": "media case",
+      "qwen_reasoning": "The object is a rectangular item with a visible cover that includes text and a photograph. The text on the cover reads \"Blue Jasmine\" and appears to be a title, likely for a film or book. The presence of a person's face in the photograph and the layout suggest it is a media product, such as a DVD or Blu-ray case, or possibly a book cover. The object is clearly a packaged media item, not a physical item like a book or a DVD disc itself, but the case or cover. The white background is masking the surrounding area, but the object itself is identifiable as a media case."
+    },
+    {
+      "asset_name": "gso_Circo_Fish_Toothbrush_Holder_14995988",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8470,
+      "qwen_classification": "children's sippy cup",
+      "qwen_reasoning": "The object is a bright green, rounded container with a lid and a spout or opening on the side. It has a playful, cartoonish design with protruding elements on top that resemble handles or ears. The color scheme includes green, light blue, and orange accents. This design is typical of children's drinkware, such as a sippy cup or a water bottle designed for young children. The spout suggests it is meant for drinking, and the overall shape and features are consistent with a child's cup or bottle."
+    },
+    {
+      "asset_name": "gso_Brother_Printing_Cartridge_PC501",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8341,
+      "qwen_classification": "electronic component package",
+      "qwen_reasoning": "The image shows a close-up of a product package. The visible text \"PC-501\" is likely a model number or product code. The graphic on the package depicts several small, black, cylindrical objects with wires or leads extending from them, which are characteristic of electronic components. Specifically, these shapes strongly resemble surface-mount device (SMD) resistors or capacitors, which are commonly packaged in small quantities for electronics assembly. The packaging style (blue and white box with technical graphics) is typical for electronic component distributors. Therefore, the object is a package of electronic components, likely resistors or capacitors."
+    },
+    {
+      "asset_name": "gso_Chelsea_lo_fl_rdheel_nQ0LPNF1oMw",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8287,
+      "qwen_classification": "pump",
+      "qwen_reasoning": "The object is a single shoe, specifically a women's pump or heel. It has a pointed toe, a smooth, solid-colored upper (appearing magenta or deep pink), and a visible insole. The shape and design are characteristic of formal or dress shoes. The view is from the side, showing the profile of the shoe, including the heel and toe box. The material appears to be suede or a similar fabric, based on the texture and sheen. There are no visible laces or straps, confirming it is a slip-on style."
+    },
+    {
+      "asset_name": "gso_Calphalon_Kitchen_Essentials_12_Cast_Iron_Fry_Pan_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8549,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a smooth, rounded, bowl-shaped container with a slightly reflective surface. Its shape is concave, with a wide opening and sloping sides that taper toward the bottom. The material appears to be metallic or a similar glossy substance, indicated by the light reflections and subtle highlights. There are no handles, patterns, or other features that would suggest a specific use beyond general containment. This form is typical of a mixing bowl, serving bowl, or similar kitchenware, but without additional context, the most accurate classification is based on its general shape and function as a container."
+    },
+    {
+      "asset_name": "gso_Bradshaw_International_11642_7_Qt_MP_Plastic_Bowl",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8539,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a dark, curved, bowl-shaped item with a smooth surface. The shape is concave, suggesting it is designed to hold or contain something. The deep, dark color and the way light reflects off the inner surface indicate it is likely made of a solid material such as ceramic, plastic, or metal. Given its form and the context of being segmented from a scene, it is most likely a bowl or a similar container. There are no visible handles, patterns, or other features that would suggest it is something else like a hat, a cup, or a lid. The object appears to be a standard bowl, possibly for food or liquid."
+    },
+    {
+      "asset_name": "gso_CREATIVE_BLOCKS_35_MM",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8362,
+      "qwen_classification": "wooden bird toy",
+      "qwen_reasoning": "The object appears to be a stylized, blocky representation of a bird, likely a chicken or rooster, given the red comb-like feature on top and the overall shape. It is constructed from interlocking wooden blocks or puzzle pieces, with visible seams and different colored sections (wooden tan, red, green, gray). The design is geometric and simplified, suggesting it might be a toy, a decorative item, or a piece of art. The shape includes a pointed beak area, a body, and what appear to be wings or tail feathers. The construction method and aesthetic are reminiscent of a 3D puzzle or a wooden craft project."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Bowl_Scirocco_YellowBlue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8698,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object appears to be a bowl or a similar container. It has a curved, rounded shape with a wide opening at the top. The exterior is yellow with a decorative pattern, while the interior is a contrasting gray color. The object is partially cut off in the image, but its form is consistent with a bowl used for serving or eating. The pattern on the exterior suggests it may be decorative or for aesthetic purposes."
+    },
+    {
+      "asset_name": "gso_Chelsea_lo_fl_rdheel_zAQrnhlEfw8",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8040,
+      "qwen_classification": "shoe sole",
+      "qwen_reasoning": "The object shown is a close-up view of the sole of a shoe. It has a distinct shape with a heel counter, a forefoot area, and a visible insole. The insole is orange, while the outer sole appears to be a darker color, possibly brown or burgundy. The construction suggests it is a shoe sole, likely from a dress shoe or a similar type of footwear, given the smooth, non-textured appearance and the shape. The white background indicates it has been cropped and segmented from its original context, but the object itself is clearly identifiable as a shoe sole."
+    },
+    {
+      "asset_name": "gso_CoQ10_wSSVoxVppVD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8560,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that includes text and a large 'Co' symbol, which is commonly used to denote cobalt or cobalt-containing supplements. The bottle has a screw-on cap and appears to be a container for pills or capsules, typical of dietary supplements or pharmaceutical products. The label also shows a quantity (e.g., '60') and other text, suggesting it's a commercial product. The overall shape and features are consistent with a standard supplement bottle."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Antislip_Surfacing_Material_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8831,
+      "qwen_classification": "paper roll",
+      "qwen_reasoning": "The object is a cylindrical roll of white material with a visible inner core. The surface appears smooth and uniform, consistent with materials used for wrapping, labeling, or printing. The shape and context suggest it is a roll of paper or similar thin material, commonly used in printers, label makers, or packaging equipment. The slight shadowing and curvature indicate it is a physical roll, not a flat sheet. Given the lack of any printed text, logos, or specific markings, it is likely a generic roll of paper or label stock."
+    },
+    {
+      "asset_name": "gso_Cascadia_8_Color_AquariusHibscsBearingSeaBlk_Size_50",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8195,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a curved, semi-circular piece with a textured red surface and a black border. The red surface has a pattern of small, raised bumps, which is characteristic of a grip or tread design. The black border is smooth and forms the outer edge. This shape and texture are consistent with a component of a shoe, specifically the heel or sole area of a shoe, where grip and durability are important. The curved shape suggests it is part of a larger, circular or semi-circular structure, such as the heel counter or a sole tread pattern. Given the context and appearance, it is most likely a part of a shoe, possibly a heel or sole component."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Dishtowel_BlueWhite",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8312,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a folded textile with horizontal stripes in various shades of blue and gray. The texture appears soft and absorbent, consistent with materials used for towels. The way it is folded and the visible weave pattern suggest it is a household or personal care item designed for drying or wiping. The color scheme and pattern are typical for bath towels or hand towels."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Deep_Bowl_Good_Earth_1075",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8536,
+      "qwen_classification": "colander",
+      "qwen_reasoning": "The object is a round, ribbed container with a central hole at the top. The ribbed texture and shape suggest it is designed to hold something, likely for drainage or to allow air circulation. The hole in the center is consistent with objects used for draining liquids or for ventilation. The overall form and features are characteristic of a colander or strainer, commonly used in kitchens for washing or draining food. The color and material appear to be plastic, which is typical for such household items."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Butter_Dish_Square_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8556,
+      "qwen_classification": "battery holder",
+      "qwen_reasoning": "The object is a red, plastic item with a hinged lid and a small protrusion on the side. The shape and design are consistent with a small container, possibly for holding items like batteries, screws, or other small hardware. The lid appears to be designed to snap or hinge open, and the protrusion could be a handle or a mechanism for attachment or dispensing. Given the context and appearance, it is most likely a small storage container or a battery holder, commonly found in electronics or tool kits."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Dishtowel_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8266,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object appears to be a folded piece of fabric with a distinct pattern. The pattern consists of multiple colored sections, including brown, blue, and a checkered design. The texture and appearance suggest it is a textile material, possibly a towel, blanket, or piece of clothing. The way it is folded and the visible seams indicate it is a manufactured item with a designed pattern. Given the context and visual evidence, it is most likely a towel or a similar textile product."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Flower_Pot_1025",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8572,
+      "qwen_classification": "flower pot",
+      "qwen_reasoning": "The object is a small, conical, terracotta-style pot with a slightly flared rim and a rounded base. Its shape and material appearance are consistent with a small flower pot or plant container, commonly used for growing small plants or herbs. The texture and color suggest it is made of clay or ceramic, and the design is typical of traditional gardening pots."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Dishtowel_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8197,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a rectangular, folded item with a pattern of horizontal stripes in red and white. The texture and appearance suggest it is made of fabric, likely a textile product. Given its shape and pattern, it is most likely a towel, specifically a bath towel or hand towel, which is commonly striped and folded for storage or display. The folds and the way it is presented are consistent with how towels are typically shown in product images."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Saucer_Glazed_6",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8433,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, shallow dish with a smooth, slightly glossy surface and a raised rim. Its reddish-brown color and simple, unadorned form suggest it is a ceramic or earthenware plate or shallow bowl, commonly used for serving food or as a decorative item. The shape and material are consistent with traditional pottery."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Dishtowel_Multicolors",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8378,
+      "qwen_classification": "scarf",
+      "qwen_reasoning": "The object appears to be a piece of fabric with a distinct pattern, likely a textile such as a scarf, shawl, or piece of clothing. It has a plaid or checkered design with blue, green, and brown colors. The way it is folded or draped suggests it is a flexible, soft material. The edges are irregular, indicating it is not a rigid object. Given the pattern and texture, it is most likely a decorative or wearable textile item."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Electric_Pot_Assortment_55",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8689,
+      "qwen_classification": "plant pot",
+      "qwen_reasoning": "The object is a cylindrical container with a wide rim and a slightly tapered body, typical of a flower pot or plant pot. The color is a deep reddish-brown, and the surface appears to have a matte or slightly textured finish. The shape and form are consistent with common terracotta or ceramic plant pots used for gardening. There are no visible handles, spouts, or other features that would suggest it is something other than a pot for holding plants."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Mini_Honey_Dipper",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 7728,
+      "qwen_classification": "honey dipper",
+      "qwen_reasoning": "The object shown is a long, slender tool with a handle that has a flared, ridged top section. This design is characteristic of a honey dipper, which is specifically used for scooping and drizzling honey. The ridged top helps in gripping and controlling the flow of viscous substances like honey, while the long handle allows for easy use without getting sticky hands. The shape and features match a standard honey dipper used in kitchens."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Dishtowel_Stripe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8274,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object shown is a folded textile with horizontal stripes of red and off-white/cream. The texture appears soft and woven, consistent with fabric used for household items. The way it is folded and the pattern suggest it is likely a towel, specifically a bath towel or kitchen towel, given its common design and material appearance. The edges are slightly frayed, which is typical for towels that have been used. There are no other features to suggest it is something else like a flag, scarf, or clothing item."
+    },
+    {
+      "asset_name": "gso_Cootie_Game_tDhURNbfU5J",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8601,
+      "qwen_classification": "cookie box",
+      "qwen_reasoning": "The object is a rectangular box with colorful, cartoonish graphics on its surface. The word \"Cookie\" is prominently displayed in a stylized font, and there are illustrations of smiling, round characters resembling cookies or candies. The design suggests it is packaging for a snack food product, likely cookies or a similar confection. The box appears to be made of cardboard and is shown at an angle, consistent with product packaging for retail display."
+    },
+    {
+      "asset_name": "gso_Connect_4_Launchers",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8656,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The image shows the packaging for a board game. The box is colorful and features cartoon characters (a yellow chick and a red crab), game pieces (blue and red launchers, rings, and a grid), and the title \"Connect 4\" prominently displayed. This is clearly the retail box for the classic Connect 4 game, which is a strategy board game where players drop colored discs into a vertical grid to get four in a row."
+    },
+    {
+      "asset_name": "gso_Colton_Wntr_Chukka_y4jO0I8JQFW",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8287,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object shown is a boot, specifically a low-cut or ankle boot. It has a visible sole with a textured pattern, a heel, and a shaft that rises to the ankle. The material appears to be leather or a similar synthetic material, with a light brown or tan color. The construction suggests it is designed for casual or workwear use, not for athletic or formal purposes. The view is from the side, showing the profile of the boot."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_School_Bell_Solid_Brass_38",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8358,
+      "qwen_classification": "hand bell",
+      "qwen_reasoning": "The object has a classic bell shape with a flared, open bottom and a narrow top. Attached to the top is a wooden handle, which is typical for hand-held bells. The material appears to be metal, likely brass or a similar alloy, given its color and sheen. This is a common design for a hand bell, often used for signaling, in schools, churches, or as a toy. The object is clearly identifiable and not ambiguous."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Hammer_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7591,
+      "qwen_classification": "mallet",
+      "qwen_reasoning": "The object shown is a tool with a large, rounded, black head and a handle that is black with yellow accents. This design is characteristic of a mallet, which is commonly used for striking objects without damaging them, such as in woodworking or upholstery. The head is not sharp or pointed like a claw hammer, and the handle appears to be designed for a firm grip, consistent with a mallet used for heavy-duty tasks. The object is clearly identifiable as a mallet based on its distinct shape and features."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Electric_Pot_Cabana_55",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8701,
+      "qwen_classification": "cd",
+      "qwen_reasoning": "The object is a circular, concave shape with a central hole, appearing to be made of a translucent orange material. The lighting and shadows suggest a three-dimensional, bowl-like structure. The shape and central hole are characteristic of a CD or DVD disc, which is commonly made of polycarbonate plastic and has a reflective surface. The orange color may indicate it is a colored or custom disc, or it could be a stylized representation. The object lacks the typical reflective surface of a standard CD/DVD, but the overall form is unmistakably that of a disc."
+    },
+    {
+      "asset_name": "gso_Crayola_Model_Magic_Modeling_Material_White_3_oz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8389,
+      "qwen_classification": "modeling clay box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful branding. The visible text includes \"Model Magic\" and \"9\", which is a well-known brand of modeling clay. The box has a circular cutout on the top, likely for displaying the product inside. The design features a yellow and green color scheme with purple accents, typical of children's craft supplies. The shape and labeling confirm it is packaging for modeling clay."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Plant_Saucer_Brown_125",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8185,
+      "qwen_classification": "lid",
+      "qwen_reasoning": "The object is a dark, circular, flat item with a slightly raised rim, resembling a lid or cover. There is a small, rectangular, light-colored label or sticker on its surface. The shape and appearance are consistent with a lid for a container, such as a food container, jar, or bucket. The object lacks any distinctive features that would allow for a more specific classification (e.g., brand markings, texture, or shape variations). Therefore, the most accurate and general classification is 'lid'."
+    },
+    {
+      "asset_name": "gso_Crayola_Washable_Fingerpaint_Red_Blue_Yellow_3_count_8_fl_oz_bottes_each",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8838,
+      "qwen_classification": "art supply box",
+      "qwen_reasoning": "The object is a colorful cardboard box with branding and imagery typical of a children's art product. The visible text includes \"Crayola\" and \"Finger Paint,\" along with illustrations of children's artwork and a handprint. The box has a distinct shape with flaps and edges, consistent with packaging for a craft kit. The design, colors, and text clearly identify it as a commercial product for finger painting supplies."
+    },
+    {
+      "asset_name": "gso_Court_Attitude",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8413,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a modern, sporty design with a combination of gray, teal, and pink colors. The shoe features a lace-up closure system, a padded collar, and a visible sole structure. The style and construction suggest it is designed for athletic or casual wear, likely a sneaker or running shoe. The segmented white background confirms the focus is solely on the shoe."
+    },
+    {
+      "asset_name": "gso_Crayola_Crayons_Washable_24_crayons",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8524,
+      "qwen_classification": "crayon box",
+      "qwen_reasoning": "The object is a box with the brand name \"Crayola\" clearly visible on its side. The design includes colorful graphics and text indicating it contains \"24 Crayons\". The shape and labeling are characteristic of a standard box of Crayola crayons, a well-known brand of coloring pencils. The object is angled, showing its top and side, but the branding and product description are sufficient to identify it confidently."
+    },
+    {
+      "asset_name": "gso_Crayola_Bonus_64_Crayons",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8825,
+      "qwen_classification": "toy box",
+      "qwen_reasoning": "The image shows a brightly colored box, predominantly yellow with green and purple accents. The front of the box features the text \"Story Studio\" and illustrations suggesting it is a toy or educational kit for creating stories, possibly involving a small camera or digital device. There is a picture of a dog on the box, and diagrams showing how to use the product. The overall appearance is that of a children's product packaging, likely for a storytelling or creative playset."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Orchid_Pot_85",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8647,
+      "qwen_classification": "flower pot",
+      "qwen_reasoning": "The object is a terracotta-colored, cylindrical container with a slightly flared rim and a flat base. It has two small holes: one near the bottom edge and another near the center of the base. The shape and features are characteristic of a small flower pot or plant pot, commonly used for growing plants. The material appears to be clay or ceramic, consistent with terracotta pots. The holes are likely for drainage, which is essential for plant health. The object is shown from a side angle, revealing its curved profile and base details."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Plant_Saucer_Glazed_9",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8285,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, shallow dish with a raised rim and a textured, mottled surface. The color is a warm brownish-orange, suggesting it is made of ceramic or earthenware. The design, including the raised rim and the patterned surface, is characteristic of a traditional serving platter or shallow bowl, often used for food presentation or as a decorative piece. The object appears to be a plate or platter, not a deep bowl or container, due to its shallow depth and wide, flat profile."
+    },
+    {
+      "asset_name": "gso_Crayola_Washable_Sidewalk_Chalk_16_pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8858,
+      "qwen_classification": "chalk package",
+      "qwen_reasoning": "The object is a package of Crayola chalk. The packaging is colorful and features the Crayola brand logo. The text on the package clearly reads \"CHALK\" and \"16\" indicating it contains 16 pieces. The design includes illustrations of chalk sticks in various colors, and the overall shape is a rectangular box with a handle at the top, typical for a retail chalk package. The colors and branding are unmistakable for Crayola products."
+    },
+    {
+      "asset_name": "gso_D_ROSE_45",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8352,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a high-top athletic shoe with a distinctive yellow and brown pattern. It has a visible sole, lacing system, and upper structure typical of sneakers. The design suggests it is a modern, stylized sneaker, possibly for casual wear or athletic use. The segmented view shows the side profile, highlighting its shape and color scheme."
+    },
+    {
+      "asset_name": "gso_Copperhead_Snake_Tieks_Brown_Snake_Print_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8023,
+      "qwen_classification": "lounge chair",
+      "qwen_reasoning": "The object appears to be a piece of furniture, specifically a lounge chair or chaise longue. It has a low, elongated frame with a reclined backrest and seat, both covered in a green cushioned material. The base or frame is made of a dark, possibly wooden or textured material. The design suggests it is meant for relaxation, with a reclined posture and cushioned support. The cropped view shows only a portion of the object, but the characteristic shape and materials are consistent with a lounge chair."
+    },
+    {
+      "asset_name": "gso_DIM_CDG",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8557,
+      "qwen_classification": "vitamin bottle",
+      "qwen_reasoning": "The object is a cylindrical container with a screw-top cap, typical of a supplement or vitamin bottle. The label is partially visible and shows text including \"DIN + C\", which likely refers to Vitamin D and Vitamin C, common nutritional supplements. The shape, cap, and labeling are consistent with a pharmaceutical or health supplement bottle. The object is clearly identifiable as a bottle of vitamins or supplements."
+    },
+    {
+      "asset_name": "gso_Crayola_Model_Magic_Modeling_Material_Single_Packs_6_pack_05_oz_packs",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8470,
+      "qwen_classification": "art supply box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a colorful design. It features a prominent blue silhouette of a dolphin, a rainbow color wheel, and various circular icons, suggesting it is packaging for a children's product. The text \"Color\" is visible, and the overall aesthetic is playful and educational. This is characteristic of a box for art supplies, such as crayons or colored pencils, often marketed to children. The shape and design are consistent with a standard retail box for such items."
+    },
+    {
+      "asset_name": "gso_Crayola_Crayons_24_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8596,
+      "qwen_classification": "book",
+      "qwen_reasoning": "The object is a yellow book with a visible barcode on the spine and some graphics on the cover, including what appears to be a globe and a flag. The book is shown at an angle, suggesting it is a physical object with a cover and pages. The presence of a barcode and cover design indicates it is likely a commercial product, such as a textbook, children's book, or reference book. The specific content or title is not legible, but the physical form is clearly identifiable as a book."
+    },
+    {
+      "asset_name": "gso_Corningware_CW_by_Corningware_3qt_Oblong_Casserole_Dish_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8424,
+      "qwen_classification": "food container",
+      "qwen_reasoning": "The object is a rectangular, two-part container with a lid, featuring a light blue top and a darker blue base. It has rounded corners and small handles on the sides. The top surface has a recessed area with a logo or brand mark ('CW') and some text. This design is typical of a portable, sealed container used for storing or transporting items, such as food, snacks, or wipes. The shape and features suggest it is a compact, portable food container or a wet wipe container, commonly found in travel or office settings."
+    },
+    {
+      "asset_name": "gso_Crazy_Shadow_2",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8365,
+      "qwen_classification": "basketball shoe",
+      "qwen_reasoning": "The object is a high-top athletic shoe, likely designed for basketball or similar sports, based on its elevated ankle support and the visible sole pattern. The color scheme is primarily gray and black with white accents, and there is a small green logo or detail near the heel. The design features a thick, cushioned sole with a textured pattern for traction, and the upper appears to be made of synthetic materials with some mesh or breathable sections. The overall shape and construction are consistent with performance athletic footwear."
+    },
+    {
+      "asset_name": "gso_Diamond_Visions_Scissors_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7651,
+      "qwen_classification": "scissors",
+      "qwen_reasoning": "The object shown is a pair of scissors. It has two handles (one red, one gray) connected by a pivot point, and two blades that meet at a sharp point. This is the standard design of scissors used for cutting paper, fabric, or other materials. The object is clearly identifiable despite being isolated on a white background."
+    },
+    {
+      "asset_name": "gso_DPC_tropical_Trends_Hat",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8346,
+      "qwen_classification": "sun hat",
+      "qwen_reasoning": "The object is a light-colored, woven hat with a wide brim and a decorative band around the crown. The crown features a pattern of small holes, which is characteristic of certain types of sun hats, particularly those made from straw or similar materials. The shape and construction suggest it is designed for sun protection, likely for outdoor use. The orange band adds a decorative element. This is consistent with a classic sun hat or beach hat."
+    },
+    {
+      "asset_name": "gso_Crazy_Shadow_2_oW4Jd10HFFr",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8367,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is the sole of a shoe, identifiable by its characteristic shape, tread pattern, and materials. The red rubber outsole has a textured pattern for grip, and the white midsole section suggests cushioning. The green and white accents are typical of athletic footwear branding or design. The overall structure, including the heel and forefoot contours, is consistent with a sports shoe sole. Given the context and visual features, this is clearly a shoe sole, likely from an athletic or training shoe."
+    },
+    {
+      "asset_name": "gso_Dell_Series_9_Color_Ink_Cartridge_MK993_High_Yield",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8140,
+      "qwen_classification": "ink cartridge",
+      "qwen_reasoning": "The object is a packaged product with the Dell logo clearly visible. It features a colorful hexagonal design and text indicating \"COLOR COLORED COLOR\" and \"6\". This is characteristic packaging for a Dell color ink cartridge, specifically a tri-color (cyan, magenta, yellow) cartridge for printers. The green hang tab and overall design are typical for printer consumables."
+    },
+    {
+      "asset_name": "gso_Crayola_Washable_Sidewalk_Chalk_16_pack_wDZECiw7J6s",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8949,
+      "qwen_classification": "candy box",
+      "qwen_reasoning": "The object is a multi-colored cardboard box with visible branding and text. The design includes bright colors like green, yellow, blue, and orange, with graphics that resemble candy or snack packaging. The word \"CANDY\" is partially visible on the side, and there are illustrations of what appear to be candy bars or similar confections. The box has a handle on top and is shaped like a typical retail package for snacks or candy. The overall appearance strongly suggests it is a commercial product box for candy or a similar sweet treat."
+    },
+    {
+      "asset_name": "gso_Diet_Pepsi_Soda_Cola12_Pack_12_oz_Cans",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8388,
+      "qwen_classification": "beverage case",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding for 'Diet Pepsi'. The iconic Pepsi logo (a circular design with red, white, and blue segments) is visible, along with the text 'diet pepsi' and the number '12', which typically indicates a 12-pack of cans. The shape and branding are characteristic of a beverage case for canned drinks."
+    },
+    {
+      "asset_name": "gso_D_ROSE_773_II_hvInJwJ5HUD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8488,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. Key features include a curved upper section, a visible sole with a textured or patterned edge, and what looks like a lacing system or stitching along the top. The overall shape and design are consistent with footwear intended for casual or athletic use. The cropped view focuses on the side and heel area, which is typical for showcasing shoe design."
+    },
+    {
+      "asset_name": "gso_Crayola_Crayons_120_crayons",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8548,
+      "qwen_classification": "candy wrapper",
+      "qwen_reasoning": "The object appears to be a crumpled or folded package, likely a snack or candy wrapper. It has bright colors (yellow, brown, green) and visible text including the word \"BONUS!\" in purple and white. The shape is irregular and distorted, suggesting it has been crushed or folded. The presence of branding and promotional text indicates it is a commercial product wrapper, not a functional item like a container or tool. The specific design and text suggest it is a wrapper for a snack or candy item, possibly a chocolate bar or similar confection."
+    },
+    {
+      "asset_name": "gso_DPC_Handmade_Hat_Brown",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8476,
+      "qwen_classification": "hat",
+      "qwen_reasoning": "The object appears to be a dark-colored hat, likely a cowboy hat or similar wide-brimmed style, viewed from above. The visible features include a curved brim, a central crown, and what looks like a decorative band or stitching around the edge. The interior shows some structural elements, possibly a stiffener or band, and a small colorful detail near the bottom, which could be a logo or decorative element. The overall shape and construction are consistent with a hat designed for outdoor wear."
+    },
+    {
+      "asset_name": "gso_Dell_Ink_Cartridge_Yellow_31",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8323,
+      "qwen_classification": "product packaging box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a green top flap that has a cut-out handle. The main body of the box is beige or off-white with some faint text or markings. This design is typical for product packaging, especially for items like stationery, small electronics, or consumer goods. The presence of a handle suggests it is designed for easy carrying or display. The overall shape and construction are consistent with a standard retail box."
+    },
+    {
+      "asset_name": "gso_Crazy_8",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8312,
+      "qwen_classification": "helmet",
+      "qwen_reasoning": "The object appears to be a piece of athletic or protective gear, likely a helmet or headgear. It has a curved, rounded shape with a glossy finish, and features a color scheme of white, purple, and black. The visible strap or chin guard suggests it is designed to fit securely on the head. The overall design is consistent with helmets used in sports like cycling, skateboarding, or other action sports, or possibly a protective helmet for activities like motorcycling or construction. The cropped view focuses on the side and front portion, showing the structural contours and strap attachment point."
+    },
+    {
+      "asset_name": "gso_DRAGON_W",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 7994,
+      "qwen_classification": "sandal",
+      "qwen_reasoning": "The object appears to be a single shoe, likely a sandal or slip-on style, with a distinct color pattern. It has a dark base color (possibly black or dark brown) with horizontal stripes in a lighter color (possibly tan or beige) and a reddish-orange accent near the toe area. The shape suggests it is designed for the foot, with a curved sole and an open toe. The style is casual and appears to be a single shoe, not a pair, as only one is visible in the image."
+    },
+    {
+      "asset_name": "gso_Crunch_Girl_Scouts_Candy_Bars_Peanut_Butter_Creme_78_oz_box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8663,
+      "qwen_classification": "cereal box",
+      "qwen_reasoning": "The object is a rectangular box with branding and text visible. The word \"CRUNCH\" is prominently displayed in red lettering, which is a common name for a type of cereal. The box has a blue and green color scheme, and there are images of cereal pieces and possibly a bowl. The overall shape and design are consistent with a cereal box. The text on the box includes phrases like \"Cereal\" and \"Made with real fruit,\" further confirming it is a food product packaging. The object is clearly identifiable as a cereal box."
+    },
+    {
+      "asset_name": "gso_Craftsman_Grip_Screwdriver_Phillips_Cushion",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 7329,
+      "qwen_classification": "screwdriver",
+      "qwen_reasoning": "The object shown is a long, slender tool with a handle at one end and a pointed tip at the other. The handle appears to be made of a dark, possibly rubberized or plastic material, with a blue accent near the transition to the shaft. The shaft is light-colored and appears to be made of wood or a similar material. This design is characteristic of a screwdriver, specifically one with a wooden handle and a metal shaft. The pointed tip suggests it may be a flathead or possibly a precision screwdriver, though the exact tip type is not clearly visible. The object is consistent with common hand tools used for driving screws or other fasteners."
+    },
+    {
+      "asset_name": "gso_D_ROSE_773_II_Kqclsph05pE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8123,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a close-up of a sneaker or athletic shoe. It has a reddish-brown upper with white accents, including a white sole and white stitching or paneling. There is a visible logo or emblem on the side, which is common on branded athletic footwear. The shape, lacing system, and overall design are consistent with a modern athletic shoe, likely for basketball or general sports use. The cropped view focuses on the side and heel area, but the key features are clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Design_Ideas_Drawer_Store_Organizer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8219,
+      "qwen_classification": "wooden tray",
+      "qwen_reasoning": "The object is a rectangular wooden tray or box with raised sides and a flat bottom. It appears to be made of dark wood with visible grain patterns. The shape and construction suggest it is designed to hold or contain items, such as food, utensils, or small objects. The clean lines and simple design indicate it could be used for serving, storage, or decorative purposes. There are no handles, lids, or other features that would classify it as a specific type of container beyond being a tray or shallow box."
+    },
+    {
+      "asset_name": "gso_Dell_Ink_Cartridge",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8471,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a white surface and green accents on the sides. There is a small logo or emblem visible on the top right corner, which resembles a brand logo. The box has a slightly open or torn edge on the right side, suggesting it might be a product packaging box that has been partially opened or damaged. The overall shape and design are consistent with commercial product packaging, such as for electronics, software, or consumer goods. However, without clearer branding or specific design features, it is difficult to identify the exact product."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Saucer_Electric",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8663,
+      "qwen_classification": "dish",
+      "qwen_reasoning": "The object is a circular, shallow dish with a smooth, glossy surface. It has a light pink color with a white rim or inner edge, and the concentric ridges suggest it is designed to hold or contain something. The shape and appearance are consistent with a small plate, saucer, or shallow bowl, possibly for decorative or functional use (e.g., for holding a small item, serving, or as a trinket dish). The object is not a container with a lid, nor does it resemble a typical utensil or electronic device. The lack of context (like food, liquid, or specific markings) makes it ambiguous whether it is a plate, saucer, or bowl, but the shallow depth and circular shape strongly suggest it is a dish of some kind."
+    },
+    {
+      "asset_name": "gso_Dog",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8655,
+      "qwen_classification": "teddy bear",
+      "qwen_reasoning": "The object is a plush, stuffed toy with a soft, fluffy texture. It has a rounded body, visible limbs, and distinct features such as a brown patch on its back and brown paws. The overall shape and features are consistent with a teddy bear. The object appears to be sitting or lying down, with its head turned away from the viewer. The material and construction suggest it is a children's toy, likely made of fabric and stuffing."
+    },
+    {
+      "asset_name": "gso_Eat_to_Live_The_Amazing_NutrientRich_Program_for_Fast_and_Sustained_Weight_Loss_Revised_Edition_Book",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8549,
+      "qwen_classification": "book",
+      "qwen_reasoning": "The object is a rectangular, bound item with a visible spine and cover. The cover has a distinct design with colored sections (pink, orange, and green) and what appears to be text or a barcode. This is characteristic of a book, specifically the back cover or spine area. The object's shape, binding, and printed surface are consistent with a paperback or hardcover book."
+    },
+    {
+      "asset_name": "gso_Digital_Camo_Double_Decker_Lunch_Bag",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8940,
+      "qwen_classification": "tactical bag",
+      "qwen_reasoning": "The object is a bag with a digital camouflage pattern in earthy tones (tan, brown, beige). It has a rectangular shape with visible stitching and a strap or handle on the top right corner. The design and materials suggest it is a tactical or military-style bag, possibly a duffel bag or a small backpack. The camouflage pattern is characteristic of military or outdoor gear. The visible strap with a buckle or clip indicates it is designed for carrying or securing contents. The object appears to be made of durable fabric, consistent with gear used in field or outdoor environments."
+    },
+    {
+      "asset_name": "gso_D_ROSE_ENGLEWOOD_II",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8183,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is the sole of a shoe, identifiable by its distinct shape, tread pattern, and color design. The sole has a curved, elongated form typical of footwear, with a pattern of grooves and ridges designed for traction and flexibility. The color scheme includes teal, white, and dark blue/black sections, which is common in athletic or casual shoes. The presence of a heel counter and forefoot area further confirms it is a shoe sole. Given the design, it is likely a sneaker or athletic shoe, but the specific type (e.g., running, basketball, casual) cannot be determined from this view alone."
+    },
+    {
+      "asset_name": "gso_Dino_4",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8417,
+      "qwen_classification": "horse",
+      "qwen_reasoning": "The object appears to be a stylized, possibly digital or toy representation of a horse. It has a brown, textured body with visible legs, a tail, and a head with what looks like ears and a snout. The posture is dynamic, with the horse lying on its back with legs in the air, suggesting it might be in a playful or cartoonish pose. The pixelated or low-resolution appearance suggests it could be from a video game or a digital rendering. Despite the stylization, the overall form is consistent with a horse."
+    },
+    {
+      "asset_name": "gso_Curver_Storage_Bin_Black_Small",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8740,
+      "qwen_classification": "storage bin",
+      "qwen_reasoning": "The object is a dark blue, cube-shaped container with a perforated or mesh-like pattern on its sides. It has a solid top with a small rectangular white label or panel. The design suggests it is a functional container, possibly for storage or transport. The perforations indicate it may be designed for ventilation, which is common in containers for items like electronics, tools, or even food. The overall shape and construction resemble a plastic or metal storage bin or crate, often used in industrial, commercial, or household settings. The object is not a consumer product like a phone or bottle, nor is it a piece of furniture or clothing. It appears to be a utilitarian storage or transport container."
+    },
+    {
+      "asset_name": "gso_Deskstar_Desk_Top_Hard_Drive_1_TB",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8747,
+      "qwen_classification": "food packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and graphics. On the top surface, there is a logo or brand name (partially visible as 'Nestle' or similar) and a small red square with white text. There is also a black-and-white graphic of a product, possibly a food item like a snack or beverage. The side of the box has multiple lines of small text, likely nutritional information or ingredients. The overall appearance is consistent with commercial packaging for consumer goods, specifically food or drink products. The box is not a shipping container or generic packaging, but rather branded product packaging."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Cup_B4_SAN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8548,
+      "qwen_classification": "paper cup",
+      "qwen_reasoning": "The object is a curved, hollow, cylindrical structure with a tapered shape, appearing to be made of a light brown, possibly cardboard or paper-like material. The interior is darker, suggesting depth and a hollow core. This shape is characteristic of a paper cup, specifically one that has been partially collapsed or is viewed from an angle that emphasizes its curved form. The material and form are consistent with disposable paper cups commonly used for beverages."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Garden_Pot_GP16ATurquois",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8554,
+      "qwen_classification": "plant pot",
+      "qwen_reasoning": "The object is a circular, dark-colored container with a ribbed or textured inner surface. It has a distinct central hub with multiple small holes arranged in a radial pattern, which is characteristic of a plant pot designed for drainage and root aeration. The outer rim appears to be slightly raised, and the overall shape is cylindrical. This design is typical for flower pots or planters used in gardening or horticulture."
+    },
+    {
+      "asset_name": "gso_Dixie_10_ounce_Bowls_35_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8570,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object appears to be a round, shallow container with a slightly raised rim and a smooth, curved interior. The exterior has a decorative pattern, possibly floral or abstract, in a contrasting color. This shape and design are characteristic of a small bowl, possibly for serving or decorative purposes. The material appears to be ceramic or porcelain, given the smooth finish and the way light reflects off the surface. The object is not a deep bowl, nor does it resemble a plate, cup, or other common household items. The patterned exterior suggests it may be a decorative bowl or a small serving bowl."
+    },
+    {
+      "asset_name": "gso_ENFR_MID_ENFORCER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8258,
+      "qwen_classification": "water ski boot",
+      "qwen_reasoning": "The object appears to be a water ski or wakeboard boot, based on its shape, lacing system, and the brand name \"Rapido\" visible on the strap. It has a rigid, molded structure typical of water sports footwear, designed to provide support and grip. The blue and beige color scheme and the strap with a buckle are common features in such equipment. The object is clearly segmented from the background, and the visible details are consistent with a specialized sports boot."
+    },
+    {
+      "asset_name": "gso_Dino_3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 7979,
+      "qwen_classification": "large carnivorous theropod dinosaur",
+      "qwen_reasoning": "The object depicted is a bipedal, quadrupedal reptilian creature with a long tail, sharp claws, and a muscular build. Its posture and anatomy are consistent with a theropod dinosaur, specifically resembling a Tyrannosaurus rex or a similar large carnivorous dinosaur. The segmented, textured skin and overall form suggest it is a digital rendering or model, likely from a video game or 3D animation, rather than a real-world specimen. The object is clearly identifiable as a dinosaur, and given its size, predatory features, and posture, it is best classified as a large carnivorous theropod dinosaur."
+    },
+    {
+      "asset_name": "gso_Down_To_Earth_Orchid_Pot_Ceramic_Lime",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8772,
+      "qwen_classification": "plant pot",
+      "qwen_reasoning": "The object is a square-shaped container with a hollow interior, featuring multiple small holes along the sides and a central hole at the bottom. This design is typical of a plant pot or flowerpot, which is often made of ceramic or plastic and includes drainage holes to allow excess water to escape. The bright green color and the shape suggest it is intended for holding plants. The central hole at the bottom is likely for drainage, and the side holes may be for aeration or decorative purposes. The object appears to be a standard indoor or outdoor plant pot."
+    },
+    {
+      "asset_name": "gso_DANCING_ALLIGATOR_zoWBjc0jbTs",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 7723,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object is a green plastic device with two prominent yellow circular knobs or buttons on top. It has a symmetrical, somewhat ergonomic shape with curved extensions on either side. A small, silver-colored component extends from one end, resembling a handle or trigger. This design is characteristic of a toy or a simple mechanical tool, possibly a type of clamp, holder, or manipulator. The overall appearance is playful and functional, suggesting it is not a complex electronic device. It resembles a toy or a child's educational tool, such as a 'claw' or 'grabber' used for picking up small objects, or a component of a larger toy set. The lack of visible branding or specific features makes a precise identification difficult without more context, but the form strongly suggests a toy or educational manipulative device."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Bowl_Turquoise_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8555,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a smooth, curved, bowl-shaped container with a glossy blue finish. Its shape is consistent with a bowl or a small basin, and the material appears to be ceramic or a similar smooth, non-porous substance. There are no handles, spouts, or other features that would identify it as a specific type of bowl (like a cereal bowl or mixing bowl), so it is best classified as a general bowl."
+    },
+    {
+      "asset_name": "gso_Don_Franciscos_Gourmet_Coffee_Medium_Decaf_100_Colombian_12_oz_340_g",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8791,
+      "qwen_classification": "food can",
+      "qwen_reasoning": "The object is a cylindrical container with a label that includes text, a barcode, and a small image. The shape and labeling are characteristic of a canned food product, such as a can of soup, beans, or other preserved food. The label has a beige or light-colored background with dark text and a barcode, which is typical for commercial food packaging. The container appears to be made of metal, as is common for food cans. The perspective shows the side and part of the top/bottom, but the contents are not visible. Based on these features, it is confidently identifiable as a food can."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_B4_Har",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8566,
+      "qwen_classification": "button",
+      "qwen_reasoning": "The object is a circular, dark brown item with a slightly raised rim and a flat center. There are three small, distinct white dots arranged in a triangular pattern near the center. This appearance is highly characteristic of a button, specifically a sew-on button used in clothing or accessories. The white dots are likely the button's holes or decorative elements. The overall shape and features are consistent with a standard button design."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_QP6HARVEST",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8754,
+      "qwen_classification": "box",
+      "qwen_reasoning": "The object is a solid, yellow, rectangular prism with rounded edges and corners. It appears to be a hollow box or casing, as indicated by the visible interior space. The shape and material suggest it could be a component for electronics, a housing, or a decorative item. However, without additional context or views, it is difficult to determine its exact purpose or specific type beyond being a box-like container."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Bowl_Atlas_Low",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8787,
+      "qwen_classification": "lampshade",
+      "qwen_reasoning": "The object is a rounded, bowl-shaped item with a yellowish-gold color. It has a flat base with three small holes arranged in a triangular pattern around a central hole. This design is characteristic of a ceiling light fixture shade or a lampshade, where the holes are typically for mounting or ventilation. The curved, bowl-like shape is consistent with a shade designed to diffuse light downward. The object appears to be made of a smooth, possibly ceramic or plastic material."
+    },
+    {
+      "asset_name": "gso_Down_To_Earth_Orchid_Pot_Ceramic_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8419,
+      "qwen_classification": "hose reel",
+      "qwen_reasoning": "The object is a red, curved, tubular structure with multiple circular holes along its side. The shape and design suggest it is a component designed for holding or guiding a flexible material, such as a hose or cable. The holes are likely for securing or routing the material. This design is characteristic of a hose reel or cable reel, which is used to store and dispense hoses or cables neatly. The object appears to be made of plastic or metal, and the red color is typical for such utility items. The partial view shows the curved body and a mounting bracket or base, which is common for reel installations."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_GP16AMOCHA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8487,
+      "qwen_classification": "plant pot",
+      "qwen_reasoning": "The object is a cylindrical container with a slightly flared rim and a textured, matte brown surface. Its shape and material suggest it is a pot or container, likely for holding plants or soil, given the common use of such containers in gardening. The visible wear or texture could indicate it is made of terracotta or a similar clay-based material, which is typical for plant pots. The perspective shows the side and top rim, consistent with a standard flower pot design."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Saucer_S14MOCHA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8333,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, flat item with a textured, speckled surface in shades of brown and tan. The lighting creates a gradient effect, suggesting a three-dimensional form with a raised rim. This appearance is consistent with a ceramic or stoneware plate, commonly used for serving food. The shape, texture, and coloration are typical of artisanal or rustic dinnerware."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_QP6CORAL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8813,
+      "qwen_classification": "die",
+      "qwen_reasoning": "The object is a red, cube-shaped item with white dots arranged in a pattern. The pattern of dots (one in the center, surrounded by four others) corresponds to the number six on a standard six-sided die. The object has rounded edges and corners, and its material appears to be plastic or a similar substance, consistent with common dice used in games. The perspective is angled, showing three faces of the cube, which is typical for a die when viewed in three dimensions."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_FB6_Tur",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8813,
+      "qwen_classification": "speaker grille",
+      "qwen_reasoning": "The object is a circular, dark green component with a central hub and mounting holes. It has a shallow, bowl-like shape with a raised rim and a circular cutout near the bottom. This design is characteristic of a speaker grille or a protective cover for a loudspeaker, commonly found in audio equipment or public address systems. The mounting holes suggest it is designed to be attached to a surface or enclosure. The overall form and features strongly indicate it is a speaker grille or speaker cover."
+    },
+    {
+      "asset_name": "gso_Down_To_Earth_Ceramic_Orchid_Pot_Asst_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8845,
+      "qwen_classification": "electrical switch housing",
+      "qwen_reasoning": "The object is a dark blue, square-shaped plastic component with cutouts and a recessed area. The cutouts appear to be for mounting or securing the object, and the recessed center suggests it may house a switch, sensor, or connector. This design is typical of a wall-mounted or panel-mounted electrical or electronic component, such as a switch plate, outlet cover, or control panel housing. The presence of mounting tabs or slots on the side further supports this classification. It does not resemble a consumer electronic device like a phone or remote, nor a household item like a container or tool. The object is clearly a housing or enclosure for an internal component."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_GP16A_Coral",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8593,
+      "qwen_classification": "flower pot",
+      "qwen_reasoning": "The object is a reddish-brown, cylindrical item with a curved, open top and a slightly flared rim. It has horizontal ridges or grooves around its body, which is typical of a flower pot or plant container. The shape and texture suggest it is made of clay or a similar material, commonly used for gardening. The open top indicates it is designed to hold soil and plants. The object is shown at an angle, but its form is clearly identifiable as a pot."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_URN_SAN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8792,
+      "qwen_classification": "funnel",
+      "qwen_reasoning": "The object is a conical shape with a wide open end and a narrower end, appearing to be made of a smooth, light-yellow material. Its form is consistent with a funnel, which is commonly used for pouring liquids or powders into containers. The object lacks any features that would identify it as a specific type of funnel (e.g., measuring markings, spout design), so it is best classified as a general funnel."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Pot_GP9_SAND",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8651,
+      "qwen_classification": "lampshade base",
+      "qwen_reasoning": "The object is a brown, cylindrical item with a flared base and a top surface featuring multiple holes and a central hole. The shape and features suggest it is a component designed for mounting or securing something, possibly a light fixture or a similar hardware item. The holes are likely for screws or fasteners, and the central hole may be for wiring or a mounting rod. The overall form is consistent with a lampshade base or a similar industrial or decorative hardware component."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Pot_GP9AAvocado",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8617,
+      "qwen_classification": "plant pot",
+      "qwen_reasoning": "The object is a cylindrical container with a slightly tapered shape, made of a solid green material. It has a smooth interior and exterior surface. There are small, circular cutouts near the bottom, which are likely for drainage or ventilation. The overall design and features suggest it is intended for holding plants or small items, and the drainage holes are a common feature in plant pots. The object appears to be a plastic or ceramic plant pot, possibly for seedlings or small plants."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_12_Pot_Nova",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8826,
+      "qwen_classification": "barrel",
+      "qwen_reasoning": "The object is a cylindrical container with a slightly tapered shape, featuring a metallic or painted green finish. The visible seam along its side suggests it is constructed from rolled metal or a similar material. The overall form and construction are consistent with a standard industrial or military-style barrel, commonly used for storage or transport. The object is viewed at an angle, showing its curved side and one end, which is typical for such containers. There are no markings or features to suggest it is a specialized type of barrel (e.g., beer, oil, or ammunition), so it is best classified as a general-purpose barrel."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_S24Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8056,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, flat item with a slightly raised rim and a central depression. The color is a muted teal or greenish-blue. The surface appears smooth and possibly glazed, suggesting it is made of ceramic or porcelain. The shape and features are consistent with a shallow bowl, plate, or saucer, commonly used for serving or holding food or drink. The central depression might be for stability or to hold a specific item. Given the context and appearance, it is most likely a plate or shallow bowl."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Plate_S11Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8509,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object appears to be a circular, blue item with a glossy surface, possibly a plate or a shallow bowl. The shape is round, and the color is a solid blue with some shading that suggests curvature and light reflection. The white areas are masking parts of the image, but the visible portion clearly shows a curved, circular form with a smooth, reflective surface. It lacks any distinct features like handles, patterns, or text that would identify it as a specific type of dishware beyond being a plate or bowl."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Saucer_SQ8COR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8514,
+      "qwen_classification": "tray",
+      "qwen_reasoning": "The object is a square-shaped, shallow container with raised edges, typically used for serving or baking. Its reddish-brown color and smooth, non-reflective surface suggest it is made of plastic or coated metal. The shape and design are characteristic of a food tray or baking pan, commonly found in kitchens or cafeterias. The white mask indicates the object has been isolated from its original context, but the visible features are consistent with a standard tray."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Saucer_S17MOCHA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8399,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object appears to be a circular, flat item with a dark brown rim and a lighter brown, textured center. The shape and appearance are consistent with a shallow dish or plate, possibly made of ceramic or wood. The bite mark-like indentation on the left side suggests it might be a plate that has been partially eaten from, or it could be a decorative or functional item with a deliberate cut-out. Given the context and appearance, it is most likely a plate or shallow dish."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_S24NATURAL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8164,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object appears to be a circular, shallow container with a smooth, curved rim and a slightly concave interior. The color is a uniform light brown or beige, suggesting it might be made of ceramic or plastic. The shape and form are consistent with a small plate, saucer, or shallow bowl. The cropped view shows only a portion of the object, but the curvature and depth are characteristic of such items. It does not resemble a cup, lid, or other common household items due to its shallow profile and lack of handles or spouts."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Planter_Pot_QP6Ebony",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8831,
+      "qwen_classification": "speaker",
+      "qwen_reasoning": "The object is a black, box-shaped item with rounded edges and a slightly curved front surface. It appears to be a speaker, likely a subwoofer or satellite speaker, given its compact, enclosed design and the visible circular cutouts on the front panel, which are typical for speaker drivers or ports. The object is presented in a single cropped view, and while the context is limited, its shape and features strongly suggest it is an audio device."
+    },
+    {
+      "asset_name": "gso_Epson_Ink_Cartridge_126_Yellow",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8606,
+      "qwen_classification": "printer ink cartridge package",
+      "qwen_reasoning": "The object is a product package, specifically for a printer ink cartridge. The blue and white packaging features branding (\"EPSON\" is visible), product information, and graphics that suggest it contains ink cartridges. The shape and design are typical of retail packaging for printer consumables. The white areas are masked background, not part of the object."
+    },
+    {
+      "asset_name": "gso_Embark_Lunch_Cooler_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8802,
+      "qwen_classification": "cooler bag",
+      "qwen_reasoning": "The object is a blue, soft-sided bag with a handle on top and a zipper closure. Its shape and features suggest it is designed for carrying items, likely for outdoor or travel use. The curved, somewhat rigid structure at the top indicates it may be a cooler or insulated bag, commonly used to keep food or drinks cold. The material appears to be fabric, and the overall design is compact and portable."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Quadra_Saucer_SQ1_Avocado",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8724,
+      "qwen_classification": "dish",
+      "qwen_reasoning": "The object is a square-shaped dish with raised edges and a shallow depth, appearing to be made of a solid material with a matte, olive-green finish. Its form is consistent with a small plate, bowl, or serving dish, commonly used for food presentation or as a decorative item. The perspective is angled, showing the interior and the raised rim, which is typical for such containers. There are no handles, lids, or other features that would suggest it is something other than a dish."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_Quadra_Sand_QP6",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8917,
+      "qwen_classification": "duct",
+      "qwen_reasoning": "The object is a three-dimensional, hollow, rectangular prism with rounded edges and corners. It appears to be made of a solid material, possibly metal or plastic, with a matte brown finish. The perspective shows one open end, suggesting it is a conduit or channel designed to carry something through it. The shape is consistent with a square or rectangular duct, pipe, or housing. Given the open end and the hollow interior, it is most likely a type of duct or pipe, possibly for ventilation, plumbing, or electrical wiring. The specific application is unclear from this view alone, but the form is characteristic of a duct or conduit."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Saucer_S14NATURAL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8407,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a shallow, circular dish with a smooth, slightly curved rim and a concave interior. The surface appears to be made of a material with a matte or semi-gloss finish, possibly ceramic or metal, with a gradient of color from dark brown/black on the upper left to a lighter tan/yellow on the right. The shape and form are consistent with a plate or shallow bowl, commonly used for serving food or as a decorative item. There are no handles, patterns, or other features that would suggest a specific subtype beyond being a general plate or shallow dish."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Saucer_SQ1HARVEST",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8518,
+      "qwen_classification": "keyboard keycap",
+      "qwen_reasoning": "The object is a yellow, square-shaped item with rounded corners and a slightly raised, beveled edge. The surface appears to have a matte or semi-gloss finish with a subtle texture. The shape and construction suggest it is a keycap, commonly used on computer keyboards or other mechanical input devices. The beveled edges and uniform color are characteristic of modern keyboard keycaps, which are often made of plastic and designed to fit into keyswitches. The perspective is a top-down angled view, which is typical for showcasing keycaps."
+    },
+    {
+      "asset_name": "gso_Epson_DURABrite_Ultra_786_Black_Ink_Cartridge_T786120S",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8215,
+      "qwen_classification": "ink cartridge",
+      "qwen_reasoning": "The object is a product package, specifically for an ink cartridge. The visible text \"786\" and \"EPSON\" clearly identifies it as an Epson brand ink cartridge model 786. The packaging design, including the blue and black color scheme and the shape of the box, is typical for printer ink cartridges. The object is partially obscured by white masking, but the key identifying features are present."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_S14Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8231,
+      "qwen_classification": "frying pan",
+      "qwen_reasoning": "The object is a circular, shallow container with a smooth, slightly reflective surface. The color appears to be a gradient of blue and green, suggesting it might be made of metal or coated plastic. The shape and form are consistent with a frying pan or skillet, which is commonly used for cooking. The curved rim and shallow depth are characteristic features of a frying pan. There are no handles visible in this view, but this is common in cropped or top-down views. The object lacks any other distinguishing features that would suggest it is something else, such as a bowl or plate, due to its specific shallow, wide shape and cooking-related appearance."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Saucer_S20MOCHA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8335,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, dark brown item with a smooth, slightly curved rim and a flat base. The texture appears uniform and matte, suggesting it is made of a solid material like ceramic, wood, or plastic. The shape and form are consistent with common household items such as a plate, a shallow bowl, or a saucer. Given the top-down view and the lack of any handles, decorative elements, or food residue, it is most likely a plate or a shallow bowl. However, without additional context or views, it is not possible to definitively distinguish between these possibilities."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plate_S20Avocado",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8030,
+      "qwen_classification": "lid",
+      "qwen_reasoning": "The object is a circular, green item with a smooth, slightly glossy surface. It has a raised rim and a central indentation, which is characteristic of a lid for a container. The color and texture suggest it might be made of plastic or glass. The shape and features are consistent with a lid for a jar, container, or possibly a food item like a green smoothie or soup bowl, but the central indentation and rim strongly suggest it is a lid. Given the context of being segmented and the visible features, it is most likely a container lid."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_Urn_55_Mocha",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8579,
+      "qwen_classification": "metal pipe",
+      "qwen_reasoning": "The object is a cylindrical, hollow structure with a conical or tapered shape, appearing to be made of metal with a rusted or weathered surface. The visible interior is dark, suggesting depth, and the exterior has a rough, corroded texture. This form and material are characteristic of industrial or construction components, such as a pipe, duct, or funnel. The tapering shape suggests it may be a conical pipe or a section of a larger system designed to direct flow or reduce cross-sectional area. Given the context and appearance, it is most likely a metal pipe or duct segment, possibly used in plumbing, ventilation, or industrial applications."
+    },
+    {
+      "asset_name": "gso_Epson_UltraChrome_T0543_Ink_Cartridge_Magenta_1pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8814,
+      "qwen_classification": "ink cartridge",
+      "qwen_reasoning": "The object is a rectangular package with branding visible. The word \"EPSON\" is clearly printed in blue on the top right corner, which is a well-known brand for printers and printer consumables. The design includes a pink spiral graphic, which is characteristic of Epson's packaging for ink cartridges. The overall shape and labeling strongly suggest this is a printer ink cartridge package."
+    },
+    {
+      "asset_name": "gso_FIRE_ENGINE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8472,
+      "qwen_classification": "toy fire truck",
+      "qwen_reasoning": "The object appears to be a toy vehicle, specifically resembling a fire truck. It has a red body with white accents, a ladder-like structure on top, and what look like wheels or control knobs on the side. The design is simplified and colorful, typical of children's toys. The overall shape and features strongly suggest it is a toy fire truck."
+    },
+    {
+      "asset_name": "gso_Elephant",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8636,
+      "qwen_classification": "plush elephant toy",
+      "qwen_reasoning": "The object is a plush toy shaped like an elephant. It has soft, fabric-like material, characteristic of stuffed animals. Key features include large floppy ears, a trunk, and small eyes. The elephant appears to be in a playful or dynamic pose, possibly mid-motion or falling, which is common in plush toys designed for children. The color is a muted grayish-green, and the texture suggests it is made of a soft, cuddly material. The object is clearly identifiable as a stuffed animal, specifically an elephant plush toy."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Planter_Bowl_Cole_Hardware",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8667,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object appears to be a shallow, bowl-shaped container with a smooth, curved surface. It has a light beige or off-white color and a slightly glossy finish. At the bottom, there are three small, circular indentations or holes, which are characteristic of a specific type of container. The overall shape and features strongly suggest it is a type of bowl, possibly a rice bowl or a similar serving bowl, designed for holding food or liquids. The holes at the bottom might be for drainage or to allow steam to escape, which is common in certain types of bowls used for cooking or serving."
+    },
+    {
+      "asset_name": "gso_FemDophilus",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8563,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular box with a pink and white color scheme. It has text and a barcode visible, which are typical features of product packaging. The visible text includes 'Supplement Facts' and 'Easy Refrigeration', indicating it is likely a dietary supplement or health product container. The shape and labeling are consistent with commercial product packaging."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Saucer_SQ3_Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 7885,
+      "qwen_classification": "tray",
+      "qwen_reasoning": "The object is a rectangular, flat item with a smooth, slightly glossy surface. It has a brownish color with a darker greenish-brown rim or edge. The shape and appearance are consistent with a small tray, possibly for holding items like food, utensils, or decorative objects. The perspective is angled, showing the top and one side, which is typical for a shallow tray or serving dish. There are no visible handles, patterns, or other features that would identify it as something else, such as a book or a box. The object appears to be made of ceramic or a similar material, given the finish and coloration."
+    },
+    {
+      "asset_name": "gso_F5_TRX_FG",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8100,
+      "qwen_classification": "soccer cleat",
+      "qwen_reasoning": "The object shown is a close-up view of the sole and heel area of a sports shoe. It features a bright yellow-green upper with black and blue accents, and a black rubber sole with visible studs or cleats. This design is typical of soccer cleats or football boots, which are engineered for traction on grass or turf. The shape, color scheme, and presence of studs strongly indicate it is a piece of athletic footwear designed for playing soccer."
+    },
+    {
+      "asset_name": "gso_F10_TRX_FG_ssscuo9tGxb",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8206,
+      "qwen_classification": "soccer cleat",
+      "qwen_reasoning": "The object shown is a shoe, specifically a soccer cleat. This is identifiable by its distinctive shape, the presence of three parallel stripes on the side (a signature design of Adidas), and the overall structure typical of athletic footwear designed for playing soccer. The color scheme (pink, purple, and white) and the visible lacing system further support this classification. The object is clearly segmented from its background, and the non-white regions represent the shoe itself."
+    },
+    {
+      "asset_name": "gso_FisherPrice_Make_A_Match_Game_Thomas_Friends",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8924,
+      "qwen_classification": "board game",
+      "qwen_reasoning": "The object is a colorful box with illustrations of Thomas the Tank Engine and other characters from the \"Thomas & Friends\" series. The text \"Thomas & Friends\" and \"Match Game\" is visible, indicating it is a children's board game. The design, characters, and text are all consistent with a commercial board game product."
+    },
+    {
+      "asset_name": "gso_FYW_ALTERNATION",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8274,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole of a shoe. Key features include the textured rubber outsole with visible tread patterns, a white midsole, and black accents or branding elements. The shape and structure are consistent with athletic footwear, specifically designed for grip and support during physical activity. The perspective is from below, focusing on the bottom of the shoe, which is typical for showcasing sole design."
+    },
+    {
+      "asset_name": "gso_FIRE_TRUCK",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8541,
+      "qwen_classification": "toy vehicle",
+      "qwen_reasoning": "The object is a red toy vehicle with wheels, featuring a handle on top and a visible brand name \"PlanToys\" on its side. The design suggests it is a child's ride-on or push toy, likely intended for toddlers or young children. The presence of wheels, a handle for pushing or steering, and the toy-like appearance with bright colors and simple shapes confirm it is a toy vehicle, possibly a car or a scooter."
+    },
+    {
+      "asset_name": "gso_Epson_Ink_Cartridge_Black_200",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8794,
+      "qwen_classification": "printer cartridge",
+      "qwen_reasoning": "The object is a rectangular package with a blue and white design. It has text and graphics on it, including what appears to be a product name or model number (\"E-594\") and an image of a small electronic device or component. The packaging has a hanging hole, suggesting it is designed for retail display. The overall appearance is consistent with a product box for an electronic component, such as a printer cartridge, memory card, or similar small tech item. The text and layout are typical of consumer electronics packaging."
+    },
+    {
+      "asset_name": "gso_F10_TRX_TF_rH7tmKCdUJq",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8000,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. It has a curved, elongated shape with a visible opening at one end, which is characteristic of footwear. The color scheme includes purple, pink, and white, with a red or dark-colored interior. The design suggests it is a modern, possibly casual or sporty shoe. The segmented view shows only a portion of the shoe, but the key features (shape, opening, color pattern) are consistent with a shoe."
+    },
+    {
+      "asset_name": "gso_Epson_LabelWorks_LC5WBN9_Tape_reel_labels_071_x_295_Roll_Black_on_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8320,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a blue color scheme and text printed on its surface. The visible text is too small and blurry to read clearly, but the overall shape and design are consistent with product packaging, such as for a software product, electronics, or consumer goods. The box has a three-dimensional form with visible edges and corners, and the perspective suggests it is tilted or angled. Given the context of the image being a cropped view of a single object, and the presence of printed text, it is most likely a product box."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_Urn_55_Avocado",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8610,
+      "qwen_classification": "fabric roll",
+      "qwen_reasoning": "The object is a rolled-up item with a green, textured surface, likely made of fabric or felt. The presence of a white label with a barcode at one end suggests it is a commercial product, possibly a roll of material such as carpet, fabric, or craft paper. The cylindrical shape and the way it is rolled indicate it is designed for storage or transport. The texture appears uniform and slightly fibrous, which is common in materials like felt or non-woven fabric. The label implies it is sold in retail, which supports the idea that it is a consumable or craft material rather than a durable good like a mat or rug (though those are possible). Given the visual evidence, the most likely classification is a roll of fabric or felt, but without more context, a more specific type cannot be confidently determined."
+    },
+    {
+      "asset_name": "gso_Epson_UltraChrome_T0548_Ink_Cartridge_Matte_Black_1pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8469,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular, beige-colored package or box with printed text and logos. There is a cut-out handle on one side, suggesting it is designed for carrying. The presence of text and branding (including what looks like a logo in the bottom right corner) indicates it is likely a product package. The overall shape and features are consistent with a retail box for consumer goods, possibly for electronics, cosmetics, or another product category. However, without clearer text or specific branding, a more precise classification is not possible."
+    },
+    {
+      "asset_name": "gso_Epson_LabelWorks_LC4WBN9_Tape_reel_labels_047_x_295_Roll_Black_on_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8547,
+      "qwen_classification": "milk carton",
+      "qwen_reasoning": "The object is a rectangular cardboard carton, likely for liquid, with a blue and white color scheme. It has printed text and a yellow band, which is typical for beverage cartons (like milk or juice). The shape and design are consistent with a standard 1L or 2L milk carton or similar beverage packaging. The visible text includes 'Lait' (French for milk) and '2L', confirming it is a milk carton. The carton is shown in a tilted, three-dimensional perspective, but the key identifying features are present."
+    },
+    {
+      "asset_name": "gso_FRUIT_VEGGIE_MEMO_GRADIENT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8122,
+      "qwen_classification": "chocolate cookie",
+      "qwen_reasoning": "The object consists of multiple round, flat, brown items with a slightly textured surface. Their shape, color, and uniform appearance are consistent with chocolate cookies or biscuit-like treats. The arrangement suggests they are individual pieces, possibly arranged for display or consumption. There are no visible ingredients, packaging, or other contextual clues to suggest they are something else, such as coins, buttons, or discs. The visual characteristics strongly align with baked goods, specifically chocolate cookies."
+    },
+    {
+      "asset_name": "gso_Final_Fantasy_XIV_A_Realm_Reborn_60Day_Subscription",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8235,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The object is a video game case, specifically for the PlayStation 3 console. This is evident from the visible PlayStation 3 logo at the top, the game title \"ARKANIS: REBORN\" prominently displayed, and the standard design of a physical game case with artwork and a small inset image showing gameplay or a character. The case is angled, showing its three-dimensional form, and the white background indicates it has been segmented from its original context."
+    },
+    {
+      "asset_name": "gso_Envision_Home_Dish_Drying_Mat_Red_6_x_18",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 7959,
+      "qwen_classification": "handkerchief",
+      "qwen_reasoning": "The object is a solid red, rectangular item with a slight fold or crease along its length and a diagonal white stripe near one end. The shape and appearance are consistent with a folded piece of fabric, such as a handkerchief, a small towel, or a cloth napkin. The diagonal stripe could be a decorative element or a functional marking. Given the lack of additional context or features (like stitching, texture, or branding), it is most likely a folded cloth item. The most plausible classification is a handkerchief or a small towel, but without more detail, \"handkerchief\" is the most common and fitting description for such a simple, folded red fabric item."
+    },
+    {
+      "asset_name": "gso_Frozen_Scrabble_Jr",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8825,
+      "qwen_classification": "scratch-off game box",
+      "qwen_reasoning": "The object is a rectangular box with printed graphics. The visible artwork includes characters from Disney's 'Frozen' (Anna and Elsa), along with the word 'SCRATCHABLE' and the Disney logo. This indicates it is a themed scratch-off game or activity book, likely containing scratch-off puzzles or stickers. The design and branding are consistent with children's entertainment products."
+    },
+    {
+      "asset_name": "gso_Folic_Acid",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8559,
+      "qwen_classification": "pill bottle",
+      "qwen_reasoning": "The object is a cylindrical container with a white cap and a label that has text and color (maroon and orange). The shape, cap, and labeling are characteristic of a pill bottle or supplement container commonly used for storing medication or vitamins. The label appears to have printed information, which is typical for pharmaceutical or health-related products. The object is clearly segmented from the background, and the visible features strongly suggest it is a container for pills or capsules."
+    },
+    {
+      "asset_name": "gso_FYW_DIVISION",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8344,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object in the image is a footwear item, specifically a sneaker or athletic shoe. It has a visible sole with a textured pattern, a midsole, and an upper section with what appears to be lacing and branding. The design, including the black and white color scheme and the shape, is consistent with modern athletic or casual sneakers. The perspective is a side view, showing the profile of the shoe, including the heel and toe area. The segmentation against a white background confirms it is a single object."
+    },
+    {
+      "asset_name": "gso_Epson_T5803_Ink_Cartridge_Magenta_1pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8551,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular cardboard box, likely for packaging. It has printed text on its surface, including what looks like product information and possibly a logo or brand name. The visible side shows a blue patterned section at the top, followed by a beige or light brown area with dense text. There is also a pink or magenta colored section near the bottom left. The box is angled, suggesting it's a three-dimensional object. Given the text and packaging appearance, it is most likely a product box, possibly for a consumer item like a book, electronics, or household goods. However, without clearer text or recognizable branding, a more specific classification is not possible."
+    },
+    {
+      "asset_name": "gso_GEOMETRIC_SORTING_BOARD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8674,
+      "qwen_classification": "toy blocks",
+      "qwen_reasoning": "The object appears to be a set of wooden blocks with rainbow-colored stripes. The blocks are rectangular and have a smooth, painted surface with red, yellow, green, and blue stripes. They are arranged on a wooden base or platform, suggesting they might be part of a toy set or educational tool. The design and construction are consistent with children's building blocks or stacking toys."
+    },
+    {
+      "asset_name": "gso_Fisher_price_Classic_Toys_Buzzy_Bee",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8376,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object appears to be a small, handheld toy or tool with a colorful, striped body. It has two yellow, blade-like protrusions extending from the top and bottom, and a blue cylindrical component in the center. A black string or cord is attached to one side. The design and components suggest it is likely a type of spinning top or a pull-string toy, possibly for children. The presence of the string indicates it might be used for winding or pulling to create motion. The overall structure is compact and designed for manual manipulation."
+    },
+    {
+      "asset_name": "gso_FRACTION_FUN_n4h4qte23QR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8578,
+      "qwen_classification": "craft template",
+      "qwen_reasoning": "The object is a light brown, rectangular item with embossed shapes on its surface. The shapes appear to be outlines of common household items or symbols, such as a door, a window, and possibly a house or appliance. The material looks like cardboard or a similar paper-based composite, and the embossed design suggests it might be a template, stencil, or educational tool. The object is not a standard household item like a box or container, but rather a specialized item with a patterned surface. Given the context and appearance, it is most likely a craft template or a teaching aid for learning shapes or household items."
+    },
+    {
+      "asset_name": "gso_Fujifilm_instax_SHARE_SP1_10_photos",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8280,
+      "qwen_classification": "wireless router",
+      "qwen_reasoning": "The object is a white, rectangular device with rounded corners and a smooth surface. It has a slightly raised edge and appears to be a compact electronic gadget. The faint markings on the top surface suggest it may be a brand logo or model identifier. Given its shape and appearance, it is most likely a wireless router or a similar networking device, commonly used for home or office internet connectivity. The design is minimalist and modern, consistent with consumer electronics in that category."
+    },
+    {
+      "asset_name": "gso_Footed_Bowl_Sand",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8542,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a rounded, bowl-shaped item with a smooth, matte surface and a uniform light brown or beige color. It appears to be made of ceramic or clay, given its texture and form. The shape is consistent with a traditional bowl or cup, likely used for holding food or liquids. The perspective shows the interior and exterior curves, confirming its function as a container. There are no handles, decorative elements, or other features that would suggest a specific subtype beyond being a general bowl."
+    },
+    {
+      "asset_name": "gso_Fruity_Friends",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8459,
+      "qwen_classification": "storage bin",
+      "qwen_reasoning": "The object is a bright green, rectangular plastic container with a hinged lid. It has a distinct shape with raised edges and appears to be designed for holding multiple items, possibly in a grid or compartmentalized fashion. The lid is partially open, revealing the interior. The object is sitting on a piece of cardboard, and a red spherical object is visible behind it. The overall appearance is consistent with a plastic storage bin or a small cooler, commonly used for organizing or transporting items."
+    },
+    {
+      "asset_name": "gso_Firefly_Clue_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8366,
+      "qwen_classification": "food packaging box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful graphics and text on its surface. It appears to be packaging for a product, likely a snack or food item, given the imagery of food items and the presence of what looks like a logo or brand name. The box has a distinct three-dimensional shape with visible flaps and edges, typical of commercial packaging. The design includes images of food, possibly noodles or rice dishes, and text in what appears to be Chinese characters, suggesting it is a product from an Asian market. The overall appearance is consistent with a retail food product box."
+    },
+    {
+      "asset_name": "gso_Ghost_6_Color_MdngtDenmPomBrtePnkSlvBlk_Size_50",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8243,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object in the image is a single athletic shoe, viewed from a side angle. It features a red upper with gray or silver accents, a black sole, and a visible lacing system. The design, including the shape of the sole and the overall structure, is consistent with a running or training shoe. The segmented white background isolates the shoe, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Fresca_Peach_Citrus_Sparkling_Flavored_Soda_12_PK",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8480,
+      "qwen_classification": "beverage box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding visible. The word \"FRESCA\" is prominently displayed in large, stylized lettering, which is a well-known brand of flavored sparkling water. The design includes imagery suggestive of citrus fruits (like oranges or lemons) and a light, refreshing color palette (pinks, blues, whites), consistent with beverage packaging. The shape and labeling strongly indicate it is a product box for a beverage, likely containing multiple cans or bottles of Fresca soda."
+    },
+    {
+      "asset_name": "gso_Full_Circle_Happy_Scraps_Out_Collector_Gray",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8800,
+      "qwen_classification": "shovel",
+      "qwen_reasoning": "The object is a dark blue, cone-shaped item with a curved handle or grip on top. Its shape and handle suggest it is designed to be held and used for scooping or carrying. This form factor is characteristic of a shovel or scoop, commonly used for moving materials like snow, sand, or dirt. The handle appears to be made of a lighter-colored material, possibly wood or plastic, and is integrated into the top of the scoop. The object is likely a snow shovel or a similar type of scoop, given its shape and handle design."
+    },
+    {
+      "asset_name": "gso_GIRLS_DECKHAND",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8045,
+      "qwen_classification": "slipper",
+      "qwen_reasoning": "The object appears to be a single slipper or clog-style shoe, viewed from a side angle. It has a distinct two-tone design: a brown upper section and a white sole. The shape suggests it is designed for casual or indoor wear, with a soft, flexible sole and a low-profile, open-back design typical of slippers. The material looks like soft fabric or suede for the upper and rubber or foam for the sole. The object is clearly a footwear item, specifically a slipper."
+    },
+    {
+      "asset_name": "gso_Gigabyte_GAZ97XSLI_10_motherboard_ATX_LGA1150_Socket_Z97",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8679,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The image displays a product box with prominent text \"Z97X-SLI\" and branding for \"GIGABYTE\". This is clearly the retail packaging for a computer motherboard, a key component in building or upgrading a PC. The box includes diagrams, specifications, and other typical packaging elements for computer hardware. The object is not a physical motherboard itself, but its packaging, which is still a product box."
+    },
+    {
+      "asset_name": "gso_Frozen_Olafs_In_Trouble_PopOMatic_Game_OEu83W9T8pD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8618,
+      "qwen_classification": "board game",
+      "qwen_reasoning": "The object appears to be a board game, specifically a game board with various colored pieces and structures. It has a central circular area with a die, surrounded by paths or spaces, and includes multiple colored towers or blocks (green, blue, pink) that likely represent game pieces or obstacles. The design and layout are characteristic of a strategy or resource management board game, possibly similar to games like 'Catan' or 'Settlers of Catan', though the exact game is not identifiable from this view. The presence of a die and multiple player pieces suggests it is a tabletop game for multiple players."
+    },
+    {
+      "asset_name": "gso_Frozen_Olafs_In_Trouble_PopOMatic_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8840,
+      "qwen_classification": "product package",
+      "qwen_reasoning": "The object appears to be a rectangular package or box, likely for a product. It has a blue and white color scheme with some text and graphics. On the left side, there is a visible image of a character, which appears to be Anna from Disney's 'Frozen', suggesting it is a product related to the movie. The text 'FROZEN' is partially visible, confirming the theme. The overall design and layout are typical of a commercial product package, possibly for a toy, snack, or other merchandise. The object is shown from an angled perspective, with parts of the front and side visible."
+    },
+    {
+      "asset_name": "gso_Glycerin_11_Color_BrllntBluSkydvrSlvrBlckWht_Size_80",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8096,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from an angled perspective. It features a blue upper with a mesh-like texture, black laces, and a visible logo on the side. The interior lining appears to be green, and there is a label or tag visible near the heel. The design, including the sole structure and overall shape, is consistent with a running or training shoe. The white background indicates the object has been segmented from its original context."
+    },
+    {
+      "asset_name": "gso_Great_Jones_Wingtip_kAqSg6EgG0I",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8257,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a single shoe, specifically a boot or slipper, viewed from a side angle. It has a distinct heel and sole structure, with a brownish lower section and a reddish-orange upper section. The shape and contours suggest it is a footwear item designed for the foot. The segmentation and cropping indicate it is a focused view of one shoe, not a pair or other object."
+    },
+    {
+      "asset_name": "gso_Ghost_6_Color_BlckWhtLavaSlvrCitrus_Size_80",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8170,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a light-colored upper, likely beige or off-white, with visible laces. The interior lining is a bright yellow color, and there are red accents near the sole. The sole appears to be multi-colored with red and white sections. The overall design, including the shape, lacing system, and sole pattern, is consistent with a running or training shoe. The object is clearly segmented from the background, and the white areas are just the mask, not part of the object."
+    },
+    {
+      "asset_name": "gso_GoPro_HERO3_Composite_Cable",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8103,
+      "qwen_classification": "RCA cable",
+      "qwen_reasoning": "The object shown is a cable with three distinct colored connectors: red, white, and yellow. These are standard RCA connectors, commonly used for analog audio and video signals. The red and white connectors are typically for stereo audio (right and left channels), while the yellow connector is for composite video. This type of cable is often referred to as an RCA cable or composite video/audio cable, frequently used to connect devices like DVD players, gaming consoles, or VCRs to televisions or monitors."
+    },
+    {
+      "asset_name": "gso_Germanium_GE132",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8517,
+      "qwen_classification": "jar",
+      "qwen_reasoning": "The object appears to be a small, rounded container with a lid, resembling a bottle or jar. It has a cylindrical body that tapers slightly toward the top, with a flat, circular lid. The color is a uniform brownish-tan, and there is a small, darker rectangular label or mark on the side. The shape and features are consistent with a small storage container, possibly for ink, spices, or other dry goods. However, without more context or additional views, it is difficult to be certain of its exact purpose or contents."
+    },
+    {
+      "asset_name": "gso_GRANDMOTHER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8205,
+      "qwen_classification": "toy figure",
+      "qwen_reasoning": "The object appears to be a stylized, simplified representation of a human figure lying down. It has a light-colored head, a torso with a reddish-brown garment or belt, and limbs (arms and legs) extended. The overall shape and proportions suggest it is a cartoon or toy figure, possibly a character from a video game or animation, rather than a real person or a specific piece of furniture or equipment. The lack of detailed facial features or realistic anatomy supports this interpretation. The object is segmented from its background, which is consistent with the provided context."
+    },
+    {
+      "asset_name": "gso_Glycerin_11_Color_AqrsDrsdnBluBlkSlvShckOrng_Size_50",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8297,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a close-up view of a shoe, specifically showing the side profile from the midfoot to the heel. Key features include a light blue upper with a white swoosh logo (indicative of Nike), black laces, and a white midsole with a textured outsole. The design and construction suggest it is a performance athletic shoe, likely for running or training, given the cushioned sole and streamlined silhouette. The white background indicates the object has been isolated from its original context."
+    },
+    {
+      "asset_name": "gso_Gigabyte_GA78LMTUSB3_50_Motherboard_Micro_ATX_Socket_AM3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8820,
+      "qwen_classification": "computer hardware box",
+      "qwen_reasoning": "The object is a rectangular box with branding and text visible. The text \"GIGABYTE\" and \"78LMT-USB3\" is clearly legible, which identifies it as packaging for a computer component. The model number \"78LMT-USB3\" suggests it is a motherboard, specifically a Gigabyte model with USB 3.0 support. The design includes logos and graphics typical of computer hardware packaging. The object is not a physical motherboard but its retail packaging."
+    },
+    {
+      "asset_name": "gso_HP_1800_Tablet_8GB_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8229,
+      "qwen_classification": "laptop",
+      "qwen_reasoning": "The object is a rectangular, off-white or cream-colored item with a smooth surface. It features a circular logo with the letters 'HP' inside, which is the well-known logo for Hewlett-Packard. This logo placement and the object's shape are characteristic of a laptop computer's lid or a similar electronic device. The object appears to be the top cover of a laptop, given the typical design and branding placement."
+    },
+    {
+      "asset_name": "gso_Great_Dinos_Triceratops_Toy",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8626,
+      "qwen_classification": "android mascot",
+      "qwen_reasoning": "The object is a stylized, green, cartoon-like figure with a cylindrical body, two antennae-like protrusions on top, and four limbs (two arms and two legs). It has a white stripe around its midsection and white dots on its head. This design is iconic and universally recognized as the Android mascot, which represents the Android operating system developed by Google. The object is clearly not a real-world physical item but a digital representation of a brand logo or mascot."
+    },
+    {
+      "asset_name": "gso_Granimals_20_Wooden_ABC_Blocks_Wagon_g2TinmUGGHI",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8172,
+      "qwen_classification": "can opener",
+      "qwen_reasoning": "The object shown is a manual can opener. It has a distinct mechanical design with a handle for gripping and a rotating mechanism with a cutting wheel or gear system, which is used to puncture and open the lid of metal or glass cans. The two-part handle design is typical for this type of tool, allowing for leverage and control during use. The white and gray color scheme is common for kitchen utensils, and the segmented view confirms it is a single, functional object."
+    },
+    {
+      "asset_name": "gso_Hasbro_Trivial_Pursuit_Family_Edition_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8558,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The object is a board game box. The text \"TRIVIAL PURSUIT\" is clearly visible at the top, identifying it as the classic trivia game. The box features a colorful game board graphic and other game-related imagery, which is typical for board game packaging. The shape and design are consistent with a standard board game box."
+    },
+    {
+      "asset_name": "gso_HAPPY_ENGINE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8154,
+      "qwen_classification": "toy train",
+      "qwen_reasoning": "The object appears to be a toy train, specifically a multi-car train composed of several distinct, colorful segments. The front car has a brown monkey figure on top, followed by a yellow car with a circular detail, then a blue car with a cylindrical structure and a green knob, and finally a red car with a circular detail. The design, colors, and shapes are typical of children's plastic toy trains. The white areas are background masking, not part of the object."
+    },
+    {
+      "asset_name": "gso_HeavyDuty_Flashlight",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7828,
+      "qwen_classification": "flashlight",
+      "qwen_reasoning": "The object shown is a handheld device with a cylindrical body, a prominent front lens or emitter, and a textured grip. The design, including the head with a light-emitting surface and the ergonomic handle, is characteristic of a flashlight. The red and black color scheme is common for such tools. The segmented view focuses on the main body and head, which are typical components of a flashlight."
+    },
+    {
+      "asset_name": "gso_HELICOPTER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8255,
+      "qwen_classification": "toy wrench",
+      "qwen_reasoning": "The object appears to be a wooden toy designed to resemble a wrench or a similar hand tool. It has a handle with a red and white striped pattern, a circular head with a red knob, and a small propeller-like attachment on the side. The design is simplified and stylized, typical of children's educational toys that mimic real tools. The overall shape and features suggest it is meant to be a toy wrench, possibly for pretend play or to teach children about tools."
+    },
+    {
+      "asset_name": "gso_Great_Jones_Wingtip_wxH3dbtlvBC",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8098,
+      "qwen_classification": "dress shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a side angle. It has a classic oxford-style design with a closed lacing system (indicated by the laces visible at the top), a rounded toe, and a low-profile sole. The upper appears to be made of a brown leather or suede-like material, and the sole is a contrasting reddish-brown color. The construction and style suggest it is a formal or business casual dress shoe, not a sneaker or athletic shoe."
+    },
+    {
+      "asset_name": "gso_Gigabyte_GA970AUD3P_10_Motherboard_ATX_Socket_AM3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8612,
+      "qwen_classification": "computer motherboard box",
+      "qwen_reasoning": "The object is a rectangular, black box with text and logos on its surface. The text \"GIGABYTE\" is visible at the bottom, and \"970A-UD3P\" is prominently displayed in large blue letters. There is also a gold-colored logo that appears to be the GIGABYTE brand emblem. This is characteristic packaging for a computer motherboard, which is a key component of a PC. The model number \"970A-UD3P\" is a specific motherboard model from GIGABYTE, and the branding confirms it is computer hardware packaging."
+    },
+    {
+      "asset_name": "gso_Great_Jones_Wingtip_j5NV8GRnitM",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8020,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a side angle. It has a light-colored upper, likely leather or suede, with visible stitching and a decorative row of small orange or red eyelets or stitching along the side. The sole is thick and appears to be a contrasting pink or coral color. The heel is elevated, and the overall design suggests it is a formal or dress shoe, possibly a loafer or oxford style. The shape and construction are consistent with footwear designed for formal or business wear."
+    },
+    {
+      "asset_name": "gso_Hasbro_Life_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8499,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The object is a board game box. The word \"LIFE\" is prominently displayed in large, colorful letters on the side of the box, which is the title of the classic board game. The box also features illustrations of cartoon characters and game elements, typical of board game packaging. The perspective shows the side and top of the box, confirming it is a physical game box."
+    },
+    {
+      "asset_name": "gso_Hasbro_Dont_Wake_Daddy_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8730,
+      "qwen_classification": "toy box",
+      "qwen_reasoning": "The object is a rectangular box with colorful graphics on its surface. The visible side features an illustration of children playing with toys, along with smaller images that appear to be product shots or gameplay scenes. The design and imagery strongly suggest it is packaging for a children's toy or game. The box has a typical cardboard construction with printed artwork, and the perspective shows it is angled, indicating it is a physical product box."
+    },
+    {
+      "asset_name": "gso_Guardians_of_the_Galaxy_Galactic_Battlers_Rocket_Raccoon_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8553,
+      "qwen_classification": "animated character",
+      "qwen_reasoning": "The object appears to be a stylized, cartoon-like figure, likely a character from a video game or animated media. It has a white, cat-like head with pointed ears, a blue and gray armored torso, orange pants, and striped socks. The figure is in a dynamic, mid-air pose, suggesting movement or action. The design is not realistic but rather exaggerated and playful, typical of game or animation characters. The segmented white background confirms it is a cropped image of a single object."
+    },
+    {
+      "asset_name": "gso_Granimals_20_Wooden_ABC_Blocks_Wagon_85VdSftGsLi",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8711,
+      "qwen_classification": "alphabet block",
+      "qwen_reasoning": "The object is a cube-shaped toy block with rounded edges and corners. It has a light wood-grain texture and is decorated with symbols on its visible faces: a stylized letter 'D' on the top face, a simple outline of a person or figure on one side, and a stylized letter 'A' on another side. The top face also has a light blue border. This appearance is characteristic of alphabet or educational blocks used for early childhood learning, often made of wood or plastic. The symbols suggest it is designed to teach letters and possibly basic shapes or figures."
+    },
+    {
+      "asset_name": "gso_GARDEN_SWING",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8970,
+      "qwen_classification": "chair",
+      "qwen_reasoning": "The object appears to be a wooden frame with a central cylindrical component wrapped in a metallic or reflective material. The structure includes armrests and a backrest, suggesting it is designed for seating. The cylindrical part could be a roll of material, a drum, or a component for a specific mechanical function. Given the presence of armrests and backrest, it is most likely a type of chair, possibly a specialized or industrial chair with a roll or drum mechanism. The metallic wrapping suggests it might be used for holding or processing materials, or it could be a decorative or functional element. However, without more context, it is difficult to determine its exact purpose or type beyond being a chair with a unique central feature."
+    },
+    {
+      "asset_name": "gso_Horse_Dreams_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8478,
+      "qwen_classification": "cosmetic tube",
+      "qwen_reasoning": "The object is a cylindrical container with a decorative pattern of horses in motion. The design suggests it is a cosmetic or toiletry item, such as a travel-sized tube of cream, lotion, or lip balm. The shape is consistent with a rolled-up tube, and the pattern is typical for beauty products. The cap is visible at one end, further supporting this classification."
+    },
+    {
+      "asset_name": "gso_GEOMETRIC_PEG_BOARD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8818,
+      "qwen_classification": "color sorting block set",
+      "qwen_reasoning": "The object consists of a wooden base with five vertical slots, each holding a colored block. The blocks are rectangular prisms with a stepped or notched design on their top surfaces, and they are arranged in a row. This configuration is characteristic of a classic educational toy known as a 'color sorting block' or 'stacking block' set, often used to teach color recognition, size comparison, and fine motor skills. The blocks are of different colors (blue, yellow, red, green, and a darker color) and appear to be designed to fit into corresponding slots, suggesting a matching or sorting activity. The stepped design on the top of each block is a common feature in such toys to help children identify and manipulate them."
+    },
+    {
+      "asset_name": "gso_Great_Jones_Wingtip",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8035,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows the bottom sole of a shoe, characterized by its distinct tread pattern, color (orange-red with black accents), and shape. The tread is designed for grip and durability, typical of athletic or casual footwear. The curved shape and the presence of heel and toe areas confirm it is a shoe sole. The specific design suggests it could be from a sneaker or athletic shoe, but without more context, a more specific classification like 'running shoe' or 'casual sneaker' cannot be confidently assigned. However, the object is clearly identifiable as a shoe sole."
+    },
+    {
+      "asset_name": "gso_GRANDFATHER_DOLL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8158,
+      "qwen_classification": "toy figure",
+      "qwen_reasoning": "The object appears to be a stylized, simplified human figure, likely a toy or a digital model. It has a spherical head, a torso with a blue shirt and black vest, blue pants, and simple cylindrical limbs. The overall design is blocky and lacks detailed facial features or realistic anatomy, suggesting it is not a real person but a representation. The pose (lying down) and the segmented, isolated presentation indicate it is likely a digital asset or a toy figure, possibly from a video game or animation. The lack of context makes it difficult to determine if it is a specific type of toy (e.g., action figure, doll) or a character model, but it is clearly a human-like figure."
+    },
+    {
+      "asset_name": "gso_Hey_You_Pikachu_Nintendo_64",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8392,
+      "qwen_classification": "game cartridge",
+      "qwen_reasoning": "The object is a gray cartridge with a label featuring Pikachu, the iconic Pok\u00e9mon character. The label also includes the title \"Pok\u00e9mon Red\" and an ESRB rating of \"E\" for Everyone. This is characteristic of a Nintendo Game Boy game cartridge, specifically the original \"Pok\u00e9mon Red\" game released for the Game Boy in 1996. The shape, color, and labeling are consistent with Game Boy cartridges from that era."
+    },
+    {
+      "asset_name": "gso_Home_Fashions_Washcloth_Linen",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8298,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object appears to be a folded towel. It has a soft, textured surface typical of terry cloth, with visible stitching along the top edge. The color is a light, neutral tone, and the way it is folded suggests it is a household or personal care item. The vertical seam or stripe pattern is consistent with common towel designs. There are no other features to suggest it is anything other than a towel."
+    },
+    {
+      "asset_name": "gso_Hilary",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8416,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object appears to be a dark brown, possibly leather or synthetic material, with a distinct shape that includes a heel and a raised sole. The visible stitching and the overall form suggest it is a type of footwear. The angle and cropping make it difficult to identify the exact type (e.g., boot, slipper, or shoe), but the structure is consistent with a boot or ankle boot. The presence of a zipper or seam on the side further supports this classification."
+    },
+    {
+      "asset_name": "gso_Hyaluronic_Acid",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8589,
+      "qwen_classification": "pill bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a yellow label. The label has text and a barcode, which is typical for pharmaceutical or supplement containers. The shape and design are consistent with a pill bottle or medicine container. The cap is visible on the right side, and the bottle is cylindrical with a slightly tapered neck. Based on these features, it is most likely a container for pills or capsules."
+    },
+    {
+      "asset_name": "gso_Grreat_Choice_Dog_Double_Dish_Plastic_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8096,
+      "qwen_classification": "baby feeding dish",
+      "qwen_reasoning": "The object is a divided container with two compartments, one larger and one smaller, arranged vertically. The shape is elongated and curved, resembling a bowl or dish. The material appears to be ceramic or plastic, with a light blue interior and a patterned exterior. This design is typical of a baby or toddler feeding dish, often used for separate portions of food (e.g., cereal and fruit) or for preventing spills. The curved, ergonomic shape suggests it is designed for easy handling by a child or for use in a high chair. The patterned exterior adds to its decorative or functional appeal for young children."
+    },
+    {
+      "asset_name": "gso_Home_Fashions_Washcloth_Olive_Green",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8539,
+      "qwen_classification": "cleaning sponge",
+      "qwen_reasoning": "The object appears to be a rectangular, off-white or cream-colored item with a textured, fibrous surface. The edges are irregular and slightly frayed, suggesting it is made of a soft, absorbent material. The texture and shape are consistent with a cleaning sponge, a dish sponge, or a similar household cleaning tool. The lack of any visible branding, handles, or other distinguishing features makes it difficult to be more specific than a general cleaning sponge."
+    },
+    {
+      "asset_name": "gso_Hasbro_Monopoly_Hotels_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8634,
+      "qwen_classification": "toy box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with visible branding and imagery. The text \"MOCO\" is prominently displayed in red letters on a yellow background. The box features colorful graphics, including what appears to be a cartoon character or mascot wearing a red outfit and a hat, along with other illustrations that suggest it might be a toy or game product. The box has a typical packaging design with flaps and seams, indicating it is a commercial product container. The overall appearance is consistent with a product box for a toy, game, or collectible item."
+    },
+    {
+      "asset_name": "gso_Imaginext_Castle_Ogre",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8335,
+      "qwen_classification": "video game character",
+      "qwen_reasoning": "The object is a green, muscular, humanoid figure with a crown on its head, wearing blue wristbands and a small red and white detail on its waist. Its posture is crouched or sitting, with one arm extended. This appearance is characteristic of the video game character King K. Rool from the Donkey Kong series, specifically in his classic design. The segmented, stylized look and color scheme match his iconic visual representation."
+    },
+    {
+      "asset_name": "gso_HP_Card_Invitation_Kit",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8562,
+      "qwen_classification": "user manual",
+      "qwen_reasoning": "The object appears to be a printed document or booklet, likely a user manual or product guide. This is indicated by the presence of text, diagrams, and a barcode, which are common in instructional materials. The layout includes sections with headings, bullet points, and small illustrative images, suggesting it's designed to provide information or instructions. The object is rectangular and has a glossy finish, typical of printed manuals. The visible text includes phrases like 'User Manual' and 'HP', which strongly suggests it is a product manual for an HP device. The overall appearance is consistent with a standard printed manual or guide."
+    },
+    {
+      "asset_name": "gso_HyperX_Cloud_II_Headset_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8870,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a product box, likely for a computer peripheral. The box is dark-colored with red and white accents. It features a stylized graphic of a headset or earphones with red accents, and the brand name 'GIGABYTE' is visible in red text. The design suggests it's for a gaming headset or similar audio device. The box has a standard rectangular shape with a handle cutout on one side, typical for product packaging."
+    },
+    {
+      "asset_name": "gso_Inositol",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8583,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a cylindrical container with a white cap and a red and orange label. The label has text, including the partial word \"ositol\" visible, which suggests it is a product label. The shape, cap, and labeling are characteristic of a pharmaceutical or dietary supplement bottle. The object appears to be a bottle of pills or capsules, commonly used for medication or supplements."
+    },
+    {
+      "asset_name": "gso_Hasbro_Cranium_Performance_and_Acting_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8662,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The image shows a colorful, angled view of what appears to be a product package or box. It has a distinct rectangular shape with a blue and red border at the top, and the main body is off-white or cream-colored. There are illustrations and text on the front, including what looks like a logo or brand name in the center, and various colored shapes and diagrams suggesting it might be a craft kit, educational toy, or children's activity set. The overall design is bright and playful, typical of products aimed at children or hobbyists. The white background areas are masked, leaving only the object itself visible."
+    },
+    {
+      "asset_name": "gso_Horses_in_Pink_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8358,
+      "qwen_classification": "pet tunnel",
+      "qwen_reasoning": "The object is a cylindrical, soft item with a pattern of horses on a pink background. It appears to be made of fabric and has a rolled or tube-like shape. The presence of a small blue tag or label at one end suggests it is a manufactured product, likely for pet use. Given its shape and material, it is most likely a pet tunnel or play tunnel, commonly used for cats or small dogs to provide enrichment and hiding spaces. The pattern and color are typical for pet toys designed to be visually appealing to animals."
+    },
+    {
+      "asset_name": "gso_JarroDophilusFOS_Value_Size",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8492,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a yellow and purple label. The label has text that appears to read \"Jarra Dophin\" and includes a logo. This is characteristic of a supplement or health product bottle, commonly found in pharmacies or health food stores. The shape, cap, and labeling are consistent with pharmaceutical or dietary supplement containers."
+    },
+    {
+      "asset_name": "gso_JBL_Charge_Speaker_portable_wireless_wired_Green",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8533,
+      "qwen_classification": "portable speaker",
+      "qwen_reasoning": "The object is a cylindrical, portable device with a green and white color scheme. Its shape and design suggest it is a portable speaker, commonly used for playing music or audio on the go. The textured surface and compact form factor are typical of modern Bluetooth speakers designed for portability and durability. There is a small logo or indicator visible on the side, which is common on electronic devices."
+    },
+    {
+      "asset_name": "gso_HyperX_Cloud_II_Headset_Gun_Metal",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8503,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a printed design on its surface. The design includes what looks like a stylized image of a circular object, possibly a speaker or a similar electronic component, along with text and graphics. The box has a three-dimensional shape with visible edges and corners, suggesting it is a product packaging. The overall appearance is consistent with a retail box for an electronic device or gadget. The white masking indicates the object has been cropped from its original context, but the visible features are sufficient to identify it as a product box."
+    },
+    {
+      "asset_name": "gso_JS_WINGS_20_BLACK_FLAG",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8125,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a dark-colored, high-top sneaker with visible laces and a thick sole. The design suggests it is a casual or athletic shoe, likely for everyday wear or sports. The material appears to be fabric or canvas, and the overall shape is consistent with a typical sneaker style. The angle of the image shows the side and part of the top of the shoe, but enough features are visible to confidently identify it as a shoe."
+    },
+    {
+      "asset_name": "gso_JarroSil_Activated_Silicon",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8593,
+      "qwen_classification": "food package",
+      "qwen_reasoning": "The object is a rectangular package with a predominantly purple and yellow color scheme. It features printed text, small images (possibly of food or ingredients), and a barcode on the side. The shape and labeling suggest it is a commercial product, likely a food item such as a snack bar, chocolate bar, or similar packaged good. The presence of a barcode and printed nutritional or ingredient information further supports this classification."
+    },
+    {
+      "asset_name": "gso_INTERNATIONAL_PAPER_Willamette_4_Brown_Bag_500Count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8847,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a green label on the side. The label contains text and a barcode, which is typical for commercial packaging. The top of the box has embossed text that appears to read \"9L / 18Z\", likely indicating volume or weight specifications. The overall shape and labeling suggest it is packaging for a product, possibly a consumable item like a container of food, drink, or household goods. The box appears to be sealed and unused. Based on the visible features, it is most likely a product box."
+    },
+    {
+      "asset_name": "gso_House_of_Cards_The_Complete_First_Season_4_Discs_DVD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8342,
+      "qwen_classification": "DVD case",
+      "qwen_reasoning": "The image displays a DVD case for the television series 'House of Cards'. The cover art features the title prominently, along with the names of the lead actors (Kevin Spacey, Robin Wright, and Michael Stahl-David) at the top. The central image shows a man in a suit holding two chairs, with an American flag motif integrated into the design. The text 'THE COMPLETE FIRST SEASON' is visible at the top, indicating this is a season box set. The bottom right corner shows a 'DVD' logo, confirming the media format. The object is clearly identifiable as a physical media product for a TV show."
+    },
+    {
+      "asset_name": "gso_InterDesign_Over_Door",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8611,
+      "qwen_classification": "clothes hanger rack",
+      "qwen_reasoning": "The object appears to be a metal or plastic rack with multiple curved legs ending in rounded feet, and a horizontal bar running across the top. There is also a smaller, L-shaped component attached to the top bar. This structure is consistent with a clothes hanger rack or a similar utility rack designed to hold items like clothes, towels, or other hanging objects. The design suggests it is meant to be mounted on a wall or placed on a surface, with the curved legs providing stability and the top bar serving as a hanging point."
+    },
+    {
+      "asset_name": "gso_Jarrow_Glucosamine_Chondroitin_Combination_120_Caps",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8342,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a yellow label. The label has visible text, including the words \"Glucos\" and \"Chrom\" (likely \"Glucosamine\" and \"Chromium\"), indicating it is a dietary supplement bottle. The shape, cap, and labeling are consistent with common supplement containers. The object is clearly identifiable as a supplement bottle based on its design and labeling."
+    },
+    {
+      "asset_name": "gso_Jarrow_Formulas_Glucosamine_Hci_Mega_1000_100_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8829,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a yellow label wrapped around its body. The label has text and possibly graphics, though the details are not legible in the image. The shape and design are typical of a pharmaceutical or supplement bottle, often used for pills or capsules. The cap is white and appears to be a screw-on type, common for such containers. The overall appearance strongly suggests it is a medicine or dietary supplement container."
+    },
+    {
+      "asset_name": "gso_KS_Chocolate_Cube_Box_Assortment_By_Neuhaus_2010_Ounces",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8777,
+      "qwen_classification": "gift box",
+      "qwen_reasoning": "The object is a three-dimensional, cube-shaped item wrapped in brown paper. It is adorned with a red ribbon tied in a bow on top, which is a classic presentation style for gifts. The wrapping and ribbon are typical of celebratory or present-giving contexts. The object's shape and decoration strongly suggest it is a gift box."
+    },
+    {
+      "asset_name": "gso_IsoRich_Soy",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8709,
+      "qwen_classification": "jar",
+      "qwen_reasoning": "The object is a cylindrical container with a white or off-white body and a yellow label wrapped around it. The label has text and a barcode, which is typical for consumer packaged goods. The shape and labeling suggest it is a jar or tub, commonly used for food, cosmetics, or household products. The container appears to be made of plastic or glass, and the lid is not visible, but the shape implies it is sealed. Given the context and appearance, it is most likely a food or cosmetic product container, such as a jar of cream, yogurt, or similar item. However, without visible branding or specific product details, a more precise classification is not possible."
+    },
+    {
+      "asset_name": "gso_Just_For_Men_ShampooIn_Haircolor_Jet_Black_60",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8554,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular package or box with printed text and graphics. The visible text includes the word \"NEW\" in a stylized font, along with other text in red and black. The design suggests it is a product package, likely for consumer goods. The red border and branding elements indicate it is commercial packaging. While the specific product is not identifiable from this view, the overall form and labeling are characteristic of a retail product box."
+    },
+    {
+      "asset_name": "gso_Jawbone_UP24_Wireless_Activity_Tracker_Pink_Coral_L",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8381,
+      "qwen_classification": "wristband",
+      "qwen_reasoning": "The object is a red, circular band with a small, rectangular protrusion on one side. The shape and the protrusion suggest it is a type of bracelet or wristband, possibly with a clasp or fastener mechanism. The material appears to be a solid, flexible plastic or rubber, common for casual or sporty wristbands. The design is simple and functional, lacking any intricate patterns or embellishments. Given the context and appearance, it is most likely a wristband or bracelet."
+    },
+    {
+      "asset_name": "gso_Just_For_Men_ShampooIn_Haircolor_Light_Brown_25",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8453,
+      "qwen_classification": "card",
+      "qwen_reasoning": "The object appears to be a rectangular, flat item with printed text and a blue rectangular graphic or barcode-like element. The layout and content suggest it is a document, possibly a business card, a label, or a small informational card. The blue graphic is prominent and could be a logo or a design element. Given the cropped nature and the presence of text, it is most likely a printed card or label, but without more context or clearer text, a more specific classification is not possible."
+    },
+    {
+      "asset_name": "gso_JarroSil_Activated_Silicon_5exdZHIeLAp",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8649,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a purple and yellow color scheme. It has printed text and graphics on its surface, including what appears to be a logo or brand name (possibly 'Taj' or similar) and a diagram or schematic. The box has a typical packaging design with flaps and seams, suggesting it is a commercial product package. The visible text and layout are consistent with product packaging for consumer goods, such as food, beverages, or household items. The object is clearly a packaged product, but the specific item cannot be identified without more context or clearer text."
+    },
+    {
+      "asset_name": "gso_Kingston_DT4000MR_G2_Management_Ready_USB_64GB",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8096,
+      "qwen_classification": "usb flash drive",
+      "qwen_reasoning": "The object is a black, cylindrical device with the brand name \"Kingston\" printed on it. This branding is associated with Kingston Technology, a well-known manufacturer of computer hardware. The shape and design are characteristic of a USB flash drive, which is commonly used for data storage and transfer. The object appears to be a portable storage device, likely USB 2.0 or USB 3.0 compatible, given its form factor and branding."
+    },
+    {
+      "asset_name": "gso_Krill_Oil",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8405,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that has blue and red sections. The label appears to contain text and possibly a barcode, which is typical for pharmaceutical or supplement containers. The shape and design are consistent with a common pill or vitamin bottle. Although the label text is not legible, the overall form and context strongly suggest it is a medicine or supplement container."
+    },
+    {
+      "asset_name": "gso_Little_Debbie_Donut_Sticks_6_cake_donuts_10_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8087,
+      "qwen_classification": "food box",
+      "qwen_reasoning": "The image shows a rectangular cardboard box with the words \"DONUT STICKS\" printed on it in large, bold letters. The packaging features an image of the product \u2014 small, stick-shaped donuts \u2014 and appears to be a commercial food item. The design and labeling are typical of packaged snack food. The object is clearly identifiable as a product box for donut sticks."
+    },
+    {
+      "asset_name": "gso_Logitech_Ultimate_Ears_Boom_Wireless_Speaker_Night_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8172,
+      "qwen_classification": "portable speaker",
+      "qwen_reasoning": "The object is a cylindrical, portable device with a white exterior and a black central section. It has a circular end cap with a speaker grille visible, and a red cross symbol on the side. These features are characteristic of a portable Bluetooth speaker, designed for audio playback and portability. The design is sleek and modern, typical of consumer electronics in this category."
+    },
+    {
+      "asset_name": "gso_Just_For_Men_Mustache_Beard_Brushin_Hair_Color_Gel_Kit_Jet_Black_M60",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8685,
+      "qwen_classification": "brochure",
+      "qwen_reasoning": "The object appears to be a rectangular item with text and graphics on its surface. It has a white background with red and black text, and there is a small image or logo in the top left corner. The layout and content suggest it is a printed document, likely a flyer, brochure, or informational card. The text is not legible due to the resolution and angle, but the format is consistent with promotional or informational materials. The object is not a physical product like a phone or bottle, but rather a piece of paper or cardstock."
+    },
+    {
+      "asset_name": "gso_LEGO_Fusion_Set_Town_Master",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8279,
+      "qwen_classification": "LEGO toy box",
+      "qwen_reasoning": "The object is a LEGO product box, specifically for the 'Fusion' series. The branding 'LEGO' and 'Fusion' are clearly visible, along with an age recommendation of '7-12' and an image of colorful LEGO pieces. The box is angled, showing its front and side, and appears to be a standard retail packaging for a LEGO set."
+    },
+    {
+      "asset_name": "gso_Kid_Icarus_Uprising_Nintendo_3DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8543,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The image displays the front cover of a video game case. The title \"Kid Icarus: Uprising\" is prominently featured at the top, with a character depicted in mid-air wielding a weapon. The Nintendo 3DS logo is visible on the right side, indicating the platform. The ESRB rating \"E\" (Everyone) is in the bottom left corner. This is clearly a video game box for the Nintendo 3DS console."
+    },
+    {
+      "asset_name": "gso_Lego_Friends_Advent_Calendar",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8441,
+      "qwen_classification": "toy box",
+      "qwen_reasoning": "The image shows a product box for a LEGO Friends set. The box features the LEGO logo, the 'Friends' branding, an illustration of a festive scene with a decorated tree and window, and images of the included minifigures. The age recommendation (5-12) and set number (41123) are visible. This is clearly a commercial product packaging for a children's toy."
+    },
+    {
+      "asset_name": "gso_LTyrosine",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8346,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a white, cylindrical container with a cap on one end and a red label wrapped around its body. The shape, cap, and labeling are characteristic of a typical pharmaceutical or supplement bottle. The red label likely contains product information, dosage instructions, or branding, which is standard for such containers. The object is clearly a container designed for holding pills or capsules, and the perspective shows it lying on its side."
+    },
+    {
+      "asset_name": "gso_Little_House_on_the_Prairie_Season_Two_5_Discs_Includes_Digital",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8339,
+      "qwen_classification": "DVD case",
+      "qwen_reasoning": "The object is a DVD case for the television series 'Little House on the Prairie'. This is evident from the visible text 'Little House on the Prairie' and 'SEASON TWO' on the cover. The design includes images of characters from the show, a barcode, and a purple banner indicating it is a 'DVD VIDEO' format. The object is clearly a physical media case for a TV show."
+    },
+    {
+      "asset_name": "gso_Lenovo_Yoga_2_11",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8799,
+      "qwen_classification": "laptop",
+      "qwen_reasoning": "The object shown is a laptop computer. It has a visible keyboard with keys, a screen (which appears to be displaying a blue color or is covered by a blue protective sleeve), and the characteristic hinged design of a laptop. The object is angled, showing both the keyboard and the screen area. The white background indicates it has been segmented from its original context, but the object's features are clearly identifiable as a laptop."
+    },
+    {
+      "asset_name": "gso_Kotex_U_Barely_There_Liners_Thin_60_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8692,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a black rectangular box with a glossy finish, featuring a prominent pink and white logo on the top. There is also a small image on the side, possibly depicting a product or scene. The overall design suggests it is commercial packaging, likely for a consumer product such as cosmetics, electronics, or toys. The logo and branding elements indicate it is a branded item, but without more context or clearer imagery, the specific product cannot be identified with certainty."
+    },
+    {
+      "asset_name": "gso_Leap_Frog_Paint_Dabber_Dot_Art_5_paint_bottles",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8537,
+      "qwen_classification": "science kit box",
+      "qwen_reasoning": "The image shows a rectangular box with colorful graphics and text. The visible text includes phrases like \"Fun & Easy to Use\" and \"Science Exploration for Young Scientists,\" along with illustrations of children doing science experiments. The box has a green and blue color scheme and appears to be packaging for an educational product, likely a science kit or learning toy designed for children. The design and content strongly suggest it is a product box for educational materials."
+    },
+    {
+      "asset_name": "gso_Lavender_Snake_Tieks_Snake_Print_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8313,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a slip-on shoe, likely a loafer or mule style, with a visible insole and a patterned exterior. The design features a mix of colors and a leopard-like print on the outer surface. The shape, including the rounded toe and the way the upper material is stitched, is consistent with casual footwear. The white areas are part of the shoe's design, such as the inner lining or stitching, not background."
+    },
+    {
+      "asset_name": "gso_Just_For_Men_Mustache_Beard_Brushin_Hair_Color_Gel_MediumDark_Brown_M40",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8512,
+      "qwen_classification": "men's hair care product",
+      "qwen_reasoning": "The object is a rectangular package with text and imagery. The text \"JUST FOR MEN\" is clearly visible, along with an image of a man's face and beard. This branding and imagery are characteristic of a men's grooming product, specifically a hair care or beard care product. The packaging design, including the blue and white color scheme and the depiction of a man, strongly suggests it is a product for men's hair or facial hair maintenance. The object appears to be a box or carton, likely for a hair care product such as a hair dye, conditioner, or beard balm."
+    },
+    {
+      "asset_name": "gso_Lovestruck_Tieks_Glittery_Rose_Gold_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7991,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a close-up view of a slip-on shoe, likely a flat or ballet-style shoe, with a textured, possibly patterned or glittery, upper material. The interior shows a white insole and a visible heel counter. The shape and construction suggest it is a women's casual shoe, possibly a loafer or ballet flat. The white areas are masking, not part of the shoe."
+    },
+    {
+      "asset_name": "gso_LEGO_Bricks_More_Creative_Suitcase",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8504,
+      "qwen_classification": "LEGO product box",
+      "qwen_reasoning": "The image shows a colorful box with the iconic LEGO logo prominently displayed. The box features a collage of various LEGO bricks in different colors (red, yellow, white, blue, etc.) arranged in a pattern. The design and branding are unmistakably associated with LEGO products, which are known for their interlocking plastic bricks used for building models and toys. The packaging style, including the logo placement and brick imagery, is consistent with LEGO's standard product boxes."
+    },
+    {
+      "asset_name": "gso_LEGO_Star_Wars_Advent_Calendar",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8566,
+      "qwen_classification": "LEGO toy box",
+      "qwen_reasoning": "The object is a rectangular box with branding and imagery consistent with a LEGO product. The visible text includes \"LEGO\" and \"STAR WARS,\" along with an age recommendation of \"6-14\" and a set number \"75192.\" The box features colorful illustrations of characters and scenes from the Star Wars universe, typical of LEGO set packaging. The box appears to be a standard retail packaging for a LEGO construction toy set."
+    },
+    {
+      "asset_name": "gso_LEGO_City_Advent_Calendar",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8607,
+      "qwen_classification": "LEGO set box",
+      "qwen_reasoning": "The image shows a cropped view of a LEGO product box. The LEGO logo is clearly visible at the bottom, and the box features colorful illustrations of a LEGO set, including a detailed diorama with buildings, vehicles, and figures. The box also has text and images that are typical of LEGO packaging, such as set number, theme, and age recommendations. The object is clearly identifiable as a LEGO set box, which is a type of product packaging."
+    },
+    {
+      "asset_name": "gso_Little_Big_Planet_3_Plush_Edition",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8663,
+      "qwen_classification": "video game box",
+      "qwen_reasoning": "The image displays the cover art for a video game. Key visual elements include the PlayStation 4 logo at the top, the game title \"LittleBigPlanet 3\" prominently displayed, and the subtitle \"Plush Edition\". The artwork features a large, knitted character face with big eyes and a smiling mouth, which is characteristic of the LittleBigPlanet franchise. The overall design is clearly that of a video game box for the PS4 platform."
+    },
+    {
+      "asset_name": "gso_Kong_Puppy_Teething_Rubber_Small_Pink",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8559,
+      "qwen_classification": "seashell",
+      "qwen_reasoning": "The object has a distinct spiral shape with a tapered end, resembling a seashell. The smooth, rounded contours and pinkish coloration are characteristic of certain types of gastropod shells, such as those from the family Turbinidae (turbo snails) or similar marine mollusks. The segmented appearance with concentric curves is typical of spiral shells. While it could be a man-made replica or decorative item, the form strongly suggests a natural seashell."
+    },
+    {
+      "asset_name": "gso_Lactoferrin",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8500,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a blue and gold label. The label clearly displays the brand name 'Lactoferrin' and the word 'Ferrum' (likely indicating iron content). It also shows dosage information: '250 mg' and '60 tablets'. This is characteristic of a dietary supplement bottle, specifically one containing lactoferrin, which is a protein known for its iron-binding properties and often used as a nutritional supplement."
+    },
+    {
+      "asset_name": "gso_Just_For_Men_Shampoo_In_Haircolor_Darkest_Brown_50",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8410,
+      "qwen_classification": "document",
+      "qwen_reasoning": "The object appears to be a printed document or form, likely a user agreement or terms of service page. It has a rectangular shape with text content, including a prominent box with a heading and paragraphs of fine print. The layout suggests it's a digital or printed page from a website or application, possibly viewed on a screen or printed out. The blue tint and slight angle suggest it might be a screenshot or a digitally rendered image of a document. The text is too small and blurry to read specific content, but the structure is clearly that of a formal document."
+    },
+    {
+      "asset_name": "gso_Kotobuki_Saucer_Dragon_Fly",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8575,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object appears to be a circular, shallow container with a smooth, slightly reflective surface. The visible portion shows concentric rings and a curved rim, suggesting it is a bowl or plate. The coloration is primarily white or light gray with some greenish or grayish tones, possibly from lighting or material. The shape and structure are consistent with a common household item used for serving or holding food or liquids. The cropped view focuses on the upper portion, but the overall form strongly suggests a bowl."
+    },
+    {
+      "asset_name": "gso_Little_Debbie_Cloud_Cakes_10_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8637,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular cardboard box, likely for a product. It has a red section with text and an image of a smiling child's face. There are also visible barcode and nutritional information areas, which are common on consumer packaged goods. The overall shape and labeling suggest it is a commercial product package, possibly for food or a consumer item. The child's image implies it might be targeted toward children or parents purchasing for children (e.g., cereal, snacks, or baby products)."
+    },
+    {
+      "asset_name": "gso_Lalaloopsy_Peanut_Big_Top_Tricycle",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8423,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object appears to be a small, stylized toy figure, likely a character from a children's toy line. It has a purple head with large eyes, and is holding a pink umbrella. The body is colorful and appears to be made of plastic, with parts that look like a costume or outfit. The overall design is cartoonish and playful, typical of toys designed for young children. The object is not a real-world item like a tool, appliance, or piece of clothing, but rather a manufactured toy."
+    },
+    {
+      "asset_name": "gso_Little_Debbie_Chocolate_Cupcakes_8_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8269,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box with printed text and graphics on its surfaces. It has a distinct three-dimensional shape with visible edges and corners, suggesting it is a packaged product. The presence of branding (a logo in the top left corner) and what looks like product information or instructions on the side panels indicates it is likely a commercial package for an item such as a printer cartridge, electronic device, or similar consumer product. The angled view and partial visibility of multiple sides confirm it is a box-shaped container."
+    },
+    {
+      "asset_name": "gso_Marc_Anthony_Skip_Professional_Oil_of_Morocco_Conditioner_with_Argan_Oil",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8058,
+      "qwen_classification": "cream tube",
+      "qwen_reasoning": "The object is a cylindrical tube with a cap on one end, typical of cosmetic or personal care products. The blue and yellow color scheme, along with the visible text \"MOROCCAN\" on the label, suggests it is likely a skincare product such as a moisturizer, cream, or sunscreen. The shape and labeling are consistent with commercial packaging for such items."
+    },
+    {
+      "asset_name": "gso_LADYBUG_BEAD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8271,
+      "qwen_classification": "ladybug toy",
+      "qwen_reasoning": "The object is a stylized, cartoon-like representation of a ladybug. It has a rounded, dome-shaped body with a bright red color and black spots, which are characteristic features of a ladybug. The black markings include a large, curved stripe across the back and several smaller spots. The object also has a light brown or tan underside and small protrusions that resemble legs or antennae. The overall appearance is simplified and not anatomically accurate, suggesting it is a toy, a decorative item, or a graphic representation rather than a real insect."
+    },
+    {
+      "asset_name": "gso_MINI_EXCAVATOR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8502,
+      "qwen_classification": "toy crane",
+      "qwen_reasoning": "The object is a small, toy-like vehicle with a blue body, black wheels, and a beige crane arm extending from the top. Its design resembles a construction vehicle, specifically a crane or excavator, commonly found in children's toys. The segmented, blocky style and simplified features suggest it is a toy rather than a real, functional machine. The crane arm is a key identifying feature, confirming its classification as a construction vehicle toy."
+    },
+    {
+      "asset_name": "gso_Justified_The_Complete_Fourth_Season_3_Discs_DVD",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8542,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a printed image on its surface. The image shows what looks like a person in motion, possibly running or jumping, with a blurred background suggesting speed or action. There is red text on the side of the box, which appears to be a brand name or product title. The overall shape and design are consistent with a product packaging box, likely for a video game, movie, or other media product. The perspective is angled, showing the top and one side of the box. The object is not a shoe, water bottle, or phone, and the specific product is not identifiable without more context."
+    },
+    {
+      "asset_name": "gso_Luigis_Mansion_Dark_Moon_Nintendo_3DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8566,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The object is a video game case for the Nintendo 3DS console. The cover art clearly displays the title \"Luigi's Mansion: Dark Moon\" and features Luigi, a character from the Mario franchise. The Nintendo 3DS logo is visible on the top left corner of the case. The physical form is a standard game cartridge case with a front cover and spine, typical for Nintendo 3DS games. The object is presented at an angle, showing both the front cover and the spine."
+    },
+    {
+      "asset_name": "gso_MINI_ROLLER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8549,
+      "qwen_classification": "battery",
+      "qwen_reasoning": "The object appears to be a yellow, rectangular battery with rounded edges and a metallic top. The top surface has a circular, slightly recessed area, which is characteristic of a button cell battery (like a CR2032). The yellow casing is typical for certain types of coin cell batteries, often used in electronics, calculators, or remote controls. The cropped view shows only a portion of the battery, but the visible features are consistent with this classification."
+    },
+    {
+      "asset_name": "gso_Lutein",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8556,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with an orange and green label. The label has text, including what appears to be the brand name 'Lum' in large green letters. This type of packaging is commonly used for dietary supplements, vitamins, or medications. The shape and labeling are consistent with a typical supplement bottle. The partial view and angle make it difficult to identify the exact product, but the context strongly suggests it is a health or wellness supplement container."
+    },
+    {
+      "asset_name": "gso_Mario_Luigi_Dream_Team_Nintendo_3DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8584,
+      "qwen_classification": "video game cartridge",
+      "qwen_reasoning": "The object is a video game cartridge, specifically for the Nintendo Game Boy. This is evident from the visible Nintendo logo, the Game Boy branding, the ESRB rating label, and the typical layout of game cartridge back covers which include screenshots, game description, and technical information. The cartridge is shown from its back side, which is standard for displaying game details."
+    },
+    {
+      "asset_name": "gso_Marc_Anthony_True_Professional_Strictly_Curls_Curl_Defining_Lotion",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8100,
+      "qwen_classification": "hair styling cream tube",
+      "qwen_reasoning": "The object is a tube with a tapered end, typical of cosmetic or personal care products. The visible text \"CURLS\" and \"CURLING\" suggests it is a hair product designed for styling or defining curls. The golden color and glossy finish are common for hair care items. The shape and labeling are consistent with a hair styling cream or gel tube."
+    },
+    {
+      "asset_name": "gso_LEGO_Creationary_Game_ZJa163wlWp2",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8590,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The object is a rectangular box with colorful graphics on its surface. The word \"Creationary\" is prominently displayed in green lettering. The box features illustrations of cartoon-style animals, including what appear to be chickens, ducks, and possibly other farm animals, along with some abstract or decorative elements. The design and imagery suggest it is a board game or educational toy, likely aimed at children. The box has a typical product packaging structure with visible edges and corners, and there is a small red square logo or symbol on the bottom left corner. The overall appearance is consistent with commercial game packaging."
+    },
+    {
+      "asset_name": "gso_LEUCIPPUS_ADIPURE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8165,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a side view of a shoe, specifically focusing on the heel and midsole area. It has a distinct sole with a white and grey color scheme, and the upper part appears to be made of a combination of grey and orange/brown materials. The design, including the visible lacing system and overall shape, is consistent with athletic or casual footwear. The presence of a thick, cushioned sole suggests it is likely designed for comfort and support, typical of running or training shoes. The orange accent along the side is a common design feature in athletic shoes for branding or visual appeal."
+    },
+    {
+      "asset_name": "gso_Magnifying_Glassassrt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7706,
+      "qwen_classification": "magnifying glass",
+      "qwen_reasoning": "The object has a distinct shape with a handle and a circular magnifying lens. The handle is orange and appears to be ergonomically designed for gripping, while the green part forms the frame of the magnifying glass. This is a classic design for a handheld magnifying glass, often used for reading small print, inspecting details, or in scientific/educational contexts. The object is clearly identifiable as a magnifying glass based on its functional form and common design."
+    },
+    {
+      "asset_name": "gso_MARTIN_WEDGE_LACE_BOOT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8531,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a blue, high-top style shoe with a white stripe along the side and visible lacing. The shape, including the curved toe box and heel counter, is consistent with a sneaker or athletic shoe. The material appears to be leather or a similar synthetic fabric, and the design suggests it could be a casual or sporty shoe. The view is a side profile, showing the upper part of the shoe without the sole or full context, but the key features are identifiable."
+    },
+    {
+      "asset_name": "gso_Kotex_U_Tween_Pads_16_pads",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8795,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and graphics. It has a barcode, product information, and what appears to be an image of a product (possibly a tool or electronic device) on its side. The box is typical packaging for consumer goods. The visible text includes \"SINGLE-USE\" and \"BATTERY\", suggesting it contains a single-use battery or related product. The design includes a red accent and some icons, which are common in product packaging for safety or usage instructions. The box is not a shoe, water bottle, or phone, and the specific product is not clearly identifiable from this view, but the packaging is clearly for a consumer product."
+    },
+    {
+      "asset_name": "gso_Marc_Anthony_Strictly_Curls_Curl_Envy_Perfect_Curl_Cream_6_fl_oz_bottle",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8337,
+      "qwen_classification": "hair care product",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a yellow and red color scheme. It features text and images, including two photos of women with curly hair, and the word \"CURLS\" is prominently displayed. The text on the box also mentions \"No. 1 Selling Curl Cream\" and \"Curl Defining Cream\". This indicates it is a cosmetic or hair care product packaging, specifically for a curl cream designed for curly hair."
+    },
+    {
+      "asset_name": "gso_MINI_FIRE_ENGINE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8547,
+      "qwen_classification": "binoculars",
+      "qwen_reasoning": "The object has a distinct shape with three circular lenses arranged in a row, mounted on a red and tan body. It features a handle-like structure on the left side and a spring-loaded mechanism on the right, which is characteristic of a type of binoculars or a similar optical viewing device. The design suggests it is handheld and intended for viewing distant objects, likely for recreational or observational purposes. The overall form and components strongly indicate it is a pair of binoculars, possibly a toy or simplified model given the blocky, stylized appearance."
+    },
+    {
+      "asset_name": "gso_LACING_SHEEP",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8157,
+      "qwen_classification": "spinning top",
+      "qwen_reasoning": "The object has a distinctive spiral or coiled shape, composed of multiple stacked, circular or oval segments. It has a light beige or off-white color, suggesting it might be made of wood or a similar natural material. There are several protruding wooden pegs or handles extending from the sides, which are typical of a traditional toy or educational tool. The overall form strongly resembles a classic wooden spinning top or a type of stacking toy, often used for children's play or as a sensory item. The spiral design and the pegs are characteristic features of a 'spinning top' or 'spiral top' toy, which is designed to be spun and balanced on a point."
+    },
+    {
+      "asset_name": "gso_Markings_Desk_Caddy",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8320,
+      "qwen_classification": "soap",
+      "qwen_reasoning": "The object is a dark, rectangular block with a slightly textured surface and a small white label on top. Its shape and appearance are consistent with a standard bar of soap, which is often rectangular and comes with a label for branding or product information. The object lacks any features that would suggest it is a tool, electronic device, or food item. The lighting and perspective suggest it is a solid, non-reflective object, typical of soap."
+    },
+    {
+      "asset_name": "gso_Mattel_SKIP_BO_Card_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8089,
+      "qwen_classification": "card game",
+      "qwen_reasoning": "The object is a rectangular package with a bright green color scheme. The word \"SKIP-BO\" is prominently displayed in stylized, colorful lettering on the front. This is the name of a well-known card game. The packaging includes a hang tab at the top, typical of retail card game packaging. The overall design and branding clearly identify it as a commercial product for the Skip-Bo card game."
+    },
+    {
+      "asset_name": "gso_Mad_Gab_Refresh_Card_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8943,
+      "qwen_classification": "puzzle book",
+      "qwen_reasoning": "The object is a box with prominent branding. The text \"MAD GAB\" is displayed in large, stylized blue letters with a purple outline. Additional text includes \"IT'S WHEN YOU NEED IT\" and \"200 PUZZLES\". The box is orange with a sunburst pattern in the background. The design and text suggest it is a puzzle product, likely a puzzle book or game box. The \"200 PUZZLES\" text confirms it contains multiple puzzles, and the \"MAD GAB\" branding is consistent with a known puzzle brand. The box appears to be a standard rectangular cardboard package for consumer products."
+    },
+    {
+      "asset_name": "gso_Mario_Party_9_Wii_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8511,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a colorful, illustrated design on its surface. The artwork includes cartoon-like characters and vibrant, swirling patterns, suggesting it is likely a product package, such as for a video game, anime merchandise, or a collectible item. The box has visible edges and a slightly angled perspective, indicating it is a three-dimensional container. The style and content of the artwork are typical of Japanese pop culture products, such as anime or manga-related items. The white background is masking the surrounding environment, but the object itself is clearly identifiable as a packaged product."
+    },
+    {
+      "asset_name": "gso_Matte_Black_Tieks_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8151,
+      "qwen_classification": "ballet flat",
+      "qwen_reasoning": "The object appears to be a single shoe, specifically a ballet flat or slip-on style. It has a dark-colored sole and upper, with a light-colored insole or lining visible. The shape is consistent with a women's flat shoe, and the lack of laces or straps suggests it's designed for comfort and ease of wear, typical of ballet flats or casual slip-ons. The view is a side profile, showing the curvature of the sole and the top of the shoe."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Chunky_Puzzle_Vehicles",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8366,
+      "qwen_classification": "toy vehicle playset",
+      "qwen_reasoning": "The object appears to be a children's toy set, specifically a playset or board game featuring multiple toy vehicles. The vehicles include a red car, a blue car, a yellow car, and a red truck, all arranged on a blue surface with what looks like a road or track layout. The design suggests it is intended for play, likely involving racing or movement of the vehicles along the depicted path. The style and components are typical of a toy vehicle playset."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Cart_Turtle_Block",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8402,
+      "qwen_classification": "turtle",
+      "qwen_reasoning": "The object appears to be a stylized, cartoonish turtle. It has a distinct shell made of colorful geometric shapes (green, yellow, red), a green head with large eyes, and small green limbs. The overall design is blocky and simplified, suggesting it might be a toy, a character from an animation, or a digital illustration. The presence of a small brown detail on top of its head (possibly a shell ornament or antenna) further supports its identity as a turtle character."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Jumbo_Knob_Puzzles_Barnyard_Animals",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7655,
+      "qwen_classification": "puzzle piece",
+      "qwen_reasoning": "The object appears to be a children's puzzle or a jigsaw puzzle piece. It has a distinct shape with cutouts and is decorated with cartoon animal illustrations (a cat, a dog, and a bird) on a red background with yellow borders. The style is typical of educational toys for young children. The white areas are masks, not part of the object. The object is clearly identifiable as a puzzle piece based on its shape and decorative content."
+    },
+    {
+      "asset_name": "gso_Mens_ASV_Billfish_Boat_Shoe_in_Dark_Brown_Leather_zdHVHXueI3w",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8134,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, specifically a dark-colored, lace-up boat shoe or casual dress shoe. It has visible laces, a rounded toe, and a low-profile sole. The style suggests it is designed for casual or everyday wear, not for athletic or specialized purposes. The construction appears to be leather or a similar synthetic material, and the overall design is classic and versatile."
+    },
+    {
+      "asset_name": "gso_Mens_Billfish_Ultra_Lite_Boat_Shoe_in_Dark_Brown_Blue_c6zDZTtRJr6",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8112,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a side angle. It has a dark brown upper, a visible lacing system, and a thick sole with a blue stripe along the edge. The design and construction suggest it is a casual or athletic shoe, possibly a slip-on or low-top style. The segmented white background confirms it is the isolated object of interest."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Pound_and_Roll",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8774,
+      "qwen_classification": "color matching toy",
+      "qwen_reasoning": "The object is a wooden toy with a square top surface featuring four circular holes, each containing a colored ball (green, orange, blue, red). The base has a multi-level structure with additional colored circles and slots, suggesting it is designed for children to match colors or fit balls into corresponding holes. This is a classic educational toy, often called a 'color matching toy' or 'shape sorter' with balls. The design is simple, sturdy, and intended for early childhood development."
+    },
+    {
+      "asset_name": "gso_Mastic_Gum",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8349,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that includes text and an image of broccoli. The visible text on the label reads \"Elastic Gum\". This suggests it is a dietary supplement or health product, likely a chewable gum containing ingredients such as glucosamine or chondroitin, which are often marketed for joint health and are sometimes called \"elastic gum\" due to their purported effects on connective tissue. The presence of a nutritional facts panel (partially visible) further supports that this is a health or dietary supplement product. The bottle shape and labeling are consistent with typical supplement packaging."
+    },
+    {
+      "asset_name": "gso_Mens_Billfish_Slip_On_in_Coffee_e8bPKE9Lfgo",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8438,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. It has a distinct curved shape with a visible sole and upper structure. The color pattern includes brown and white stripes or panels, which is common in athletic footwear. The visible stitching and material texture suggest it is a manufactured shoe. The cropped view shows only a portion of the shoe, but the features are consistent with a typical sneaker design."
+    },
+    {
+      "asset_name": "gso_Mens_Billfish_Slip_On_in_Tan_Beige_aaVUk0tNTv8",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8228,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a single shoe, viewed from a side angle. It has a visible sole, lacing system, and upper structure. The design appears to be a casual or athletic sneaker, with a layered color scheme including beige, brown, and light blue accents. The presence of laces and the overall shape are definitive indicators of a shoe. The white background is a segmentation artifact, not part of the object."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_See_Spell",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8354,
+      "qwen_classification": "educational toy",
+      "qwen_reasoning": "The image displays a children's educational toy, specifically a magnetic letter set. It features colorful, magnetic letters arranged to spell out the words 'bus' and 'fish'. The letters are designed to be placed on a magnetic board or surface. The toy also includes small illustrations (a bus and a fish) corresponding to the words, and there are additional magnetic letters and numbers visible at the bottom. This type of toy is commonly used for early childhood education to teach letter recognition, spelling, and vocabulary."
+    },
+    {
+      "asset_name": "gso_Mens_Santa_Cruz_Thong_in_Chocolate_lvxYW7lek6B",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8121,
+      "qwen_classification": "sandal",
+      "qwen_reasoning": "The object is a single sandal with a thong-style strap across the top of the foot. It has a flat sole and appears to be made of materials like rubber or foam for the sole and leather or synthetic material for the strap. The design is typical of casual or beach sandals. The object is clearly identifiable as footwear, specifically a type of flip-flop or thong sandal."
+    },
+    {
+      "asset_name": "gso_Mens_ASV_Shock_Light_Bungee_in_Light_Grey_xGCOvtLDnQJ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8375,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a close-up view of the sole of a shoe. The sole has a distinct wavy, treaded pattern designed for grip and traction. The material appears to be rubber or a similar synthetic compound, common in footwear soles. The visible portion includes the heel and part of the forefoot, with the upper part of the shoe (likely the upper material) visible at the top edge. This is clearly a component of a shoe, specifically the outsole."
+    },
+    {
+      "asset_name": "gso_Mens_Gold_Cup_ASV_Dress_Casual_Venetian_in_Dark_Brown_Leather",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8090,
+      "qwen_classification": "loafer",
+      "qwen_reasoning": "The object is a single slip-on shoe, likely a loafer, characterized by its smooth black upper material, visible stitching along the edge, and a low-profile sole. The interior lining appears to be a contrasting tan or brown color. The design lacks laces or buckles, confirming it is a slip-on style. The shape and construction are consistent with casual or dress loafers."
+    },
+    {
+      "asset_name": "gso_Mens_Bahama_in_Khaki_Oyster_xU2jeqYwhQJ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8119,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. It has a white upper with a blue stripe running along the side, a visible white sole, and a lacing system. The shape and design are consistent with common casual or athletic footwear. The view is a side profile, showing the curvature of the shoe and the heel counter. The white background indicates it has been cropped and segmented from its original context, but the object's features are clear enough for identification."
+    },
+    {
+      "asset_name": "gso_Mens_Bahama_in_Black_b4ADzYywRHl",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8171,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has a curved, elongated shape with a distinct sole and upper structure. The top surface appears to have a textured or patterned area, which is typical for grip or design on footwear. The overall form strongly resembles a shoe, specifically a sneaker or athletic shoe, given its streamlined profile and the presence of what looks like a lacing or strap area. The blue coloration and smooth finish suggest it might be a modern or stylized design, but the fundamental shape is consistent with footwear."
+    },
+    {
+      "asset_name": "gso_Mens_Santa_Cruz_Thong_in_Tan_r59C69daRPh",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8008,
+      "qwen_classification": "flip-flop",
+      "qwen_reasoning": "The object is a single sandal with a dark-colored sole and a light brown strap. It has the characteristic design of a flip-flop, with a thong strap that goes between the toes and a flat sole. The strap appears to be made of leather or a similar material and has a small logo or brand mark on it. The overall structure and design are consistent with casual footwear intended for warm weather or beach use."
+    },
+    {
+      "asset_name": "gso_Mens_Mako_Canoe_Moc_2Eye_Boat_Shoe_in_Coffee_9d05GG33QQQ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8246,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a top-down perspective. It has a brown leather-like upper, a visible lacing system with dark laces, and a thick sole with a contrasting greenish-yellow trim along the edge. The shape and construction suggest it is a casual or boat-style shoe, possibly a loafer or slip-on with laces. The stitching and overall design are consistent with footwear intended for everyday wear."
+    },
+    {
+      "asset_name": "gso_Mens_Billfish_3Eye_Boat_Shoe_in_Dark_Tan_wyns9HRcEuH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8310,
+      "qwen_classification": "bicycle saddle",
+      "qwen_reasoning": "The object has the distinct shape of a bicycle saddle (also known as a bike seat). It features a curved, elongated form with a padded top surface, typical for rider comfort. The color scheme includes brown and tan tones with decorative stitching or paneling, suggesting it is a designed component for a bicycle. The visible underside shows structural elements that would support mounting to a bicycle frame. The overall design and contours are consistent with a bicycle seat, not a shoe, bag, or other object."
+    },
+    {
+      "asset_name": "gso_Mens_ASV_Billfish_Boat_Shoe_in_Tan_Leather_wmUJ5PbwANc",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8130,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from the side. It has a rounded toe, a low-profile sole, and appears to be a slip-on style with a strap or decorative element across the top. The material looks like leather or a synthetic equivalent, with a brownish-gold color and some metallic sheen. The design is consistent with casual or dress shoes, possibly boat shoes or loafers, given the strap detail and overall silhouette. The white background indicates it has been cropped and segmented from its original context."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Shape_Sorting_Clock",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8376,
+      "qwen_classification": "clock puzzle",
+      "qwen_reasoning": "The object is a wooden clock puzzle, designed for children. It features a circular base with numbers 1 through 12 arranged around the perimeter, representing the hours on a clock face. There are also various shaped pieces (like stars, hearts, and geometric shapes) that fit into slots around the clock face, likely representing minutes or decorative elements. A red hour hand and a white minute hand are present, which can be moved to set the time. This type of toy is commonly used to teach children how to tell time in an interactive and engaging way."
+    },
+    {
+      "asset_name": "gso_Mens_Largo_Slip_On_in_Taupe_gooyS417q4R",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8199,
+      "qwen_classification": "loafer",
+      "qwen_reasoning": "The object is a single slip-on shoe, likely a loafer or moccasin, shown from a top-down perspective. It has a soft, suede-like texture and a rounded toe. The interior shows a visible insole with some text or branding, and the shoe appears to be unadorned with laces or buckles, consistent with slip-on footwear. The shape and construction are typical of casual or dress loafers."
+    },
+    {
+      "asset_name": "gso_Mens_Mako_Canoe_Moc_2Eye_Boat_Shoe_in_OysterTaupe_otyRrfvPMiA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8108,
+      "qwen_classification": "boat shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a side angle. It has a classic boat shoe design with visible stitching along the upper, a low-profile sole, and a rounded toe. The color is a light brown or tan, and the interior appears darker. The construction suggests it is a casual, comfortable shoe, likely made of leather or a similar material. The style is consistent with traditional boat shoes or loafers, often worn for casual or nautical settings."
+    },
+    {
+      "asset_name": "gso_Mens_Tremont_Kiltie_Tassel_Loafer_in_Black_Amaretto_FT0I9OjSA6O",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7939,
+      "qwen_classification": "loafer",
+      "qwen_reasoning": "The object is a single slip-on shoe with a rounded toe and a decorative tassel on the vamp. The construction appears to be leather or a similar material, and the style is characteristic of a loafer. The interior is visible, showing a dark lining, and the sole is flat, consistent with casual or dress loafers. The angle is a side profile view, showing the shoe's silhouette and structure."
+    },
+    {
+      "asset_name": "gso_Mens_Billfish_Slip_On_in_Coffee_nK6AJJAHOae",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8094,
+      "qwen_classification": "moccasin",
+      "qwen_reasoning": "The object is a single slip-on shoe with a moccasin-style design. It features a soft, suede-like brown upper, a visible seam along the edge, and a light-colored lacing system that appears to be decorative rather than functional for closure. The sole is flat and appears to be made of rubber or a similar material. This style is commonly known as a moccasin or a loafer, often worn for casual or comfortable indoor/outdoor use. The object is clearly identifiable as footwear."
+    },
+    {
+      "asset_name": "gso_Mens_Tremont_Kiltie_Tassel_Loafer_in_Black_Amaretto_rCdzRZqgCnI",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8125,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is the sole of a shoe, identifiable by its characteristic shape, tread pattern, and the distinct heel and toe areas. The surface has a textured design typical of shoe soles for grip and durability. The overall form and structure are consistent with the bottom of a footwear item, likely a casual or athletic shoe given the design. There are no other contextual clues to suggest it is anything other than a shoe sole."
+    },
+    {
+      "asset_name": "gso_Nescafe_16Count_Dolce_Gusto_Cappuccino_Capsules",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8907,
+      "qwen_classification": "coffee capsule box",
+      "qwen_reasoning": "The image shows a box with multiple circular, colorful capsules arranged in a grid. The text on the box, though partially obscured, appears to read \"dolce-gusto\" which is a well-known brand of coffee capsules. The capsules themselves are typical of single-serve coffee pods used in espresso machines. The design and branding strongly indicate this is a package of coffee capsules."
+    },
+    {
+      "asset_name": "gso_Mens_Santa_Cruz_Thong_in_Chocolate_La1fo2mAovE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7904,
+      "qwen_classification": "sandal",
+      "qwen_reasoning": "The object shown is a single sandal, viewed from the side or bottom. It has a flat sole with a light-colored, possibly rubber or foam material, and a strap made of a brownish material (likely leather or synthetic) that goes over the foot. The design is typical of a flip-flop or thong sandal, which is commonly worn for casual or beach use. The white background indicates it has been cropped and segmented from its original context, but the object's form is clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Mens_Wave_Driver_Kiltie_Moc_in_Tan_Leather",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 7973,
+      "qwen_classification": "holster",
+      "qwen_reasoning": "The object appears to be a curved, brown leather item with visible stitching and a strap with a buckle or tie. The shape and construction are consistent with a holster, specifically designed to hold a handgun or similar firearm. The curved form suggests it is meant to be worn on the body, likely at the waist or hip, and the strap allows for secure attachment. The material and design are typical of traditional leather holsters used for concealed or open carry."
+    },
+    {
+      "asset_name": "gso_Mens_Mako_Canoe_Moc_2Eye_Boat_Shoe_in_Coffee_K9e8FoV73uZ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8184,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a dark-colored, likely black, shoe with visible laces and a rounded toe. The shape and features suggest it is a casual or dress shoe, possibly a loafer or oxford style, given the presence of laces and the overall silhouette. The view is from the side, showing the upper part and the sole edge. The material appears to be leather or a similar synthetic material. There are no clear indicators of it being a specialized shoe like a boot, sandal, or athletic shoe."
+    },
+    {
+      "asset_name": "gso_Mens_Striper_Sneaker_in_White_rnp8HUli59Y",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8024,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has the distinct shape of a shoe, with a curved upper, a visible sole, and a toe box. The color is primarily white with blue accents along the side and heel. The design appears to be a casual or athletic shoe, possibly a sneaker, given the style of the sole and upper construction. The perspective is a side view, showing the profile of the shoe. There are no clear indicators of it being a specific type like a running shoe or boot, but it is clearly a footwear item."
+    },
+    {
+      "asset_name": "gso_Mens_Gold_Cup_ASV_Capetown_Penny_Loafer_in_Black_GkQBKqABeQN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8110,
+      "qwen_classification": "guitar case",
+      "qwen_reasoning": "The object appears to be a dark, elongated item with a curved, somewhat tapered shape. It has a textured surface with visible stitching or seams along its length, and a small, possibly metallic or reflective, detail near the middle. The overall form and construction suggest it is a protective case or cover for an instrument, likely a guitar or similar stringed instrument, given its shape and the way it's designed to wrap around a curved body. The object is not a shoe, tool, or electronic device based on its silhouette and surface features."
+    },
+    {
+      "asset_name": "gso_Mens_Tremont_Kiltie_Tassel_Loafer_in_Black_Amaretto",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8024,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole and lower part of a shoe. It has a black rubber outsole with a textured pattern for grip, a midsole that appears to be a lighter color (possibly beige or tan), and a visible seam or edge where the upper part of the shoe meets the sole. The shape and construction are consistent with a typical casual or dress shoe, not a specialized athletic shoe. The view is from the bottom, showing the underside of the footwear."
+    },
+    {
+      "asset_name": "gso_Mens_Gold_Cup_ASV_Capetown_Penny_Loafer_in_Black_EjPnk3E8fCs",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8098,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, specifically a slip-on style with a rounded toe and a low heel. It appears to be a casual or dress shoe, possibly a loafer or moccasin, based on its silhouette and lack of laces. The color is a dark shade, likely navy blue or black, with a lighter trim or panel near the toe. The material appears to be fabric or leather. The view is angled, showing the side and top of the shoe, which is consistent with a cropped, segmented image focusing on the object."
+    },
+    {
+      "asset_name": "gso_My_First_Rolling_Lion",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8623,
+      "qwen_classification": "toy car",
+      "qwen_reasoning": "The object appears to be a stylized, cartoonish representation of a vehicle, likely a car or truck. It has a green body with a red and yellow circular design on the front, resembling a face or emblem. There are also four brown, cylindrical shapes at the rear that look like wheels. The overall shape and features suggest it is a toy or a simplified model of a vehicle, possibly designed for children or as a decorative item."
+    },
+    {
+      "asset_name": "gso_Nescafe_Memento_Latte_Caramel_8_08_oz_23_g_packets_64_oz_184_g",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8478,
+      "qwen_classification": "coffee mix package",
+      "qwen_reasoning": "The object is a rectangular package with branding and imagery. The text \"Nestl\u00e9\" and \"Memento\" is visible, indicating it is a product from the Nestl\u00e9 company. The imagery on the package shows a cup of coffee with a caramel swirl and pieces of caramel, suggesting it is a coffee-related product, likely a flavored coffee mix or instant coffee. The packaging design is typical for consumer food products, specifically coffee or beverage mixes."
+    },
+    {
+      "asset_name": "gso_My_Monopoly_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8409,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The object is a rectangular box with colorful graphics on its surface. The visible side shows illustrations of people, possibly children, and what appears to be text or branding. The design suggests it is packaging for a product, likely a board game or educational toy, given the playful imagery and layout. The box has a distinct three-dimensional shape with visible edges and corners, confirming it is a physical container. The green color and cartoon-style artwork are typical for children's products."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Traffic_Signs_and_Vehicles",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8434,
+      "qwen_classification": "toy box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a light beige or cream-colored exterior. It has a visible label or sticker on the front, which includes a barcode and some text. The top of the box has handwritten text that appears to read \"Melissa & Doug,\" which is a well-known brand that produces educational toys and games for children. The box is likely packaging for a toy or educational product. The perspective is angled, showing the top and front of the box, and the edges are slightly worn, suggesting it may be a used or opened item. The overall shape and labeling are consistent with retail packaging for consumer goods, specifically children's products."
+    },
+    {
+      "asset_name": "gso_Metallic_Pewter_Tieks_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8008,
+      "qwen_classification": "shoe sole",
+      "qwen_reasoning": "The object shown is a single shoe sole, viewed from the bottom. It has a distinct shape with a rounded toe and heel, and a visible arch area. The color is a teal or turquoise, with darker shading along the edges and a lighter gradient in the center, suggesting a design for cushioning or grip. The segmented, isolated presentation confirms it is a sole, not the entire shoe. This is a common view for shoe soles in product images or design mockups."
+    },
+    {
+      "asset_name": "gso_NESCAFE_NESCAFE_TC_STKS_DECAF_6_CT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8643,
+      "qwen_classification": "coffee package",
+      "qwen_reasoning": "The object is a rectangular package with branding visible. The text \"Nestl\u00e9\" and \"Taster's Choice\" is clearly legible, along with a logo featuring a coffee cup. The color scheme is predominantly green and gold, which is characteristic of Nestl\u00e9 Taster's Choice coffee products. The shape and design are consistent with a retail package for ground coffee or instant coffee. The object appears to be a coffee product package, likely for ground coffee given the branding and typical packaging style."
+    },
+    {
+      "asset_name": "gso_Mens_Gold_Cup_ASV_2Eye_Boat_Shoe_in_Cognac_Leather",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8035,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a boot or a type of work boot. It has a sturdy, thick sole and a reinforced upper, with visible stitching and metal eyelets for laces. The color is dark brown with a lighter greenish-brown trim along the top edge. The shape and construction suggest it is designed for durability and protection, typical of work boots or hiking boots. The angle of the image shows the side and top of the boot, but not the full view, making it difficult to identify the exact model or brand. However, based on the visible features, it is confidently identifiable as a boot."
+    },
+    {
+      "asset_name": "gso_Mens_RR_Moc_in_Navy_Suede_vmFfijhBzL3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8103,
+      "qwen_classification": "shoe insole",
+      "qwen_reasoning": "The object is a blue, elongated, and slightly curved item with a soft, textured surface. It has a distinct shape with a rounded top and a darker underside, and a small strap or loop is visible at the bottom. This appearance is consistent with a shoe insole or a footbed, which is designed to provide cushioning and support inside a shoe. The shape and texture suggest it is meant to conform to the shape of a foot, and the strap may be for securing it in place or for handling. It does not resemble a shoe itself, but rather a component inside a shoe."
+    },
+    {
+      "asset_name": "gso_Marc_Anthony_True_Professional_Oil_of_Morocco_Argan_Oil_Treatment",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8415,
+      "qwen_classification": "candy tin",
+      "qwen_reasoning": "The object appears to be a rectangular, elongated item with a light-colored surface, possibly white or off-white, with a decorative or branded design in the center. There are two horizontal yellow stripes, one near the top and one near the middle. The central design is a stylized, cursive or script-like logo or text in a brownish color. At the bottom, there is a dark gray or black rectangular section with white text that appears to read \"JUNIOR TIN\". The object has a slight 3D appearance with visible edges and a light blue or teal-colored border or trim along the sides. The overall shape and design suggest it is a packaged product, likely a small box or container, possibly for a snack, candy, or small item. The text \"JUNIOR TIN\" strongly suggests it is a product intended for children, such as a candy tin or snack box. The design is clean and modern, with a focus on branding."
+    },
+    {
+      "asset_name": "gso_NAPA_VALLEY_NAVAJO_SANDAL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8023,
+      "qwen_classification": "sandal",
+      "qwen_reasoning": "The object shown is a close-up view of a sandal or slipper. It has a flat sole, a visible insole, and a strap or band that appears to go around the foot. The construction suggests it is designed for casual wear, possibly with a leather or synthetic material. The angle and cropping focus on the heel and midfoot area, indicating it is a footwear item. The stitching along the edge of the sole and the shape of the insole are consistent with a sandal or mule-style shoe."
+    },
+    {
+      "asset_name": "gso_Nestle_Pure_Life_Exotics_Sparkling_Water_Strawberry_Dragon_Fruit_8_count_12_fl_oz_can_aX0ygjh3bxi",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8577,
+      "qwen_classification": "snack box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful branding, featuring images of snacks and text that includes the word 'SNACKS'. The design suggests it is a commercial package for food items, likely containing multiple individual snack portions. The visual elements, such as the bright colors and product imagery, are typical of snack food packaging."
+    },
+    {
+      "asset_name": "gso_Mist_Wipe_Warmer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8569,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The image shows a product box with the brand name 'mist' visible. The box features illustrations depicting a white device with a water reservoir and a misting nozzle, along with images of hands using it. The design suggests it is a personal care or household appliance, likely for generating a fine mist, such as a facial steamer, humidifier, or similar device. The packaging includes instructional graphics and a barcode, which are typical for consumer electronics or appliances. Based on the visual cues, this is clearly a product box for an electronic device."
+    },
+    {
+      "asset_name": "gso_Nescafe_Tasters_Choice_Instant_Coffee_Decaf_House_Blend_Light_7_oz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8270,
+      "qwen_classification": "coffee pod",
+      "qwen_reasoning": "The object is a cylindrical container with a label that includes text and branding. The visible text includes \"Taster's Choice\" and \"Mocha,\" which are well-known brand names for coffee products. The shape, labeling, and color scheme (green and black) are consistent with a coffee pod or coffee container. The object appears to be a single-serve coffee pod, likely for use in a Keurig or similar coffee machine, given the branding and packaging style."
+    },
+    {
+      "asset_name": "gso_Nescafe_Momento_Mocha_Specialty_Coffee_Mix_8_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8601,
+      "qwen_classification": "coffee product packaging",
+      "qwen_reasoning": "The object is a product package, specifically for Nescaf\u00e9 Memento Mocha coffee. The packaging features branding, product name, and an image of a coffee cup with latte art. The design is typical of coffee product packaging, with a focus on the beverage and flavor (mocha). The shape suggests it is a box or carton, likely for a coffee pod or ground coffee product. The visible text 'Nescaf\u00e9 Memento' and 'Mocha' confirms it is a branded coffee product."
+    },
+    {
+      "asset_name": "gso_Metallic_Gold_Tieks_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8018,
+      "qwen_classification": "insole",
+      "qwen_reasoning": "The object shown is a single insole or footbed, likely from a shoe. It has a distinct shape designed to fit the human foot, with a contoured arch area and a heel cup. The material appears to be a soft, cushioned foam or rubber, with a teal-colored top surface and a darker brown or tan bottom layer. The presence of a brand name (partially visible as 'Babola') on the heel area confirms it is a manufactured product intended for footwear. This is not a complete shoe, but rather a component of one."
+    },
+    {
+      "asset_name": "gso_My_First_Wiggle_Crocodile",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8000,
+      "qwen_classification": "toy car",
+      "qwen_reasoning": "The object appears to be a toy or model of a vehicle, specifically resembling a car or truck. It has a segmented, blocky structure with what look like wheels and a body. The bright lime-green color and simplified, geometric design suggest it is not a real vehicle but rather a toy, possibly made of plastic or wood. The segmented nature implies it might be a puzzle or an educational toy designed to be assembled or disassembled. The overall shape, with a front and rear section and wheels, strongly supports the classification as a toy car or truck."
+    },
+    {
+      "asset_name": "gso_Nestle_Carnation_Cinnamon_Coffeecake_Kit_1913OZ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8719,
+      "qwen_classification": "food box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and imagery. The visible text includes \"CINNAMON\" and \"TAINAN,\" suggesting it is a food product, likely a spice or a baked good. The image on the box shows a baked item, possibly a cinnamon roll or similar pastry. The box has a typical packaging design for consumer food products, including a logo and product name. Based on these visual cues, it is clearly a packaged food item."
+    },
+    {
+      "asset_name": "gso_NattoMax",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8595,
+      "qwen_classification": "dietary supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that prominently displays the word \"Nattokinase\" in large white letters on a blue background. The label also includes a red section with text and a logo, and indicates \"100\" and \"90\" which likely refer to the number of capsules or tablets inside. This is clearly a dietary supplement bottle, specifically for nattokinase, an enzyme derived from fermented soybeans, commonly used for cardiovascular health. The shape, labeling, and context are all consistent with a typical health supplement container."
+    },
+    {
+      "asset_name": "gso_Nestl_Crunch_Girl_Scouts_Cookie_Flavors_Caramel_Coconut_78_oz_box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8631,
+      "qwen_classification": "snack box",
+      "qwen_reasoning": "The object is a rectangular box with a predominantly purple color scheme and some pink accents. It features branding and text, including the word \"CRUNCH\" in red lettering, which is commonly associated with snack foods. The design includes images of food items and nutritional information, suggesting it is packaging for a snack product. The box appears to be a standard cardboard or paperboard packaging for a commercial food item, likely a cereal or granola bar, given the \"CRUNCH\" branding and the visual cues on the packaging."
+    },
+    {
+      "asset_name": "gso_Nestl_Skinny_Cow_Heavenly_Crisp_Candy_Bar_Chocolate_Raspberry_6_pack_462_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8620,
+      "qwen_classification": "retail display stand",
+      "qwen_reasoning": "The object appears to be a product display stand or shelf, likely for retail purposes. It has a triangular or pyramid-like shape with multiple levels. The visible surfaces show printed graphics, including images of food products (possibly snacks or cereals) and text. The color scheme includes purple and white, with some green accents. The structure has slots or compartments designed to hold items, suggesting it's meant to showcase products in a store. The perspective is angled, showing the front and side of the stand."
+    },
+    {
+      "asset_name": "gso_Nestle_Pure_Life_Exotics_Sparkling_Water_Strawberry_Dragon_Fruit_8_count_12_fl_oz_can",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8944,
+      "qwen_classification": "beverage box",
+      "qwen_reasoning": "The image shows a rectangular cardboard box with branding and text. The visible text includes 'Nestle', 'Pure Life', and 'exotics sparkling water'. The design features pink and purple colors with images of fruit, suggesting it is a beverage product. The shape and labeling are consistent with a retail box for a drink, specifically sparkling water with exotic flavors. The object is clearly identifiable as a product packaging."
+    },
+    {
+      "asset_name": "gso_Nestle_Nesquik_Chocolate_Powder_Flavored_Milk_Additive_109_Oz_Canister",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8613,
+      "qwen_classification": "food package",
+      "qwen_reasoning": "The object is a yellow, curved package with printed text and nutritional information visible. The shape and labeling suggest it is a food product, likely a snack or cereal, given the typical packaging style and the presence of a nutrition facts panel. The curved form indicates it may be a stand-up pouch or a partially opened bag. The bottom edge shows some imagery that could be of the product inside, such as cereal pieces or cookies. Based on these visual cues, it is most likely a packaged food item."
+    },
+    {
+      "asset_name": "gso_Nestle_Raisinets_Milk_Chocolate_35_oz_992_g",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8203,
+      "qwen_classification": "charcoal package",
+      "qwen_reasoning": "The object is a rectangular, yellow package with visible branding and text. The text includes \"Bakelite\" and \"400 Charcoal\", which suggests it is a product package, likely for a consumable item such as charcoal briquettes or a related product. The shape and labeling are consistent with commercial packaging for a household or outdoor use item. The object is clearly a packaged product, not a standalone item."
+    },
+    {
+      "asset_name": "gso_Netgear_Ac1750_Router_Wireless_Dual_Band_Gigabit_Router",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8698,
+      "qwen_classification": "booklet",
+      "qwen_reasoning": "The object is a black booklet or pamphlet with text and images. It appears to be a guide or manual, as indicated by the layout with sections, headings, and small photos showing people using technology. The visible text includes phrases like 'Nightbook across | Accelerate your WiFi', suggesting it's a product guide or promotional material for a WiFi-related service or device. The object is clearly a printed document, not a digital device or other physical item."
+    },
+    {
+      "asset_name": "gso_Nestle_Skinny_Cow_Dreamy_Clusters_Candy_Dark_Chocolate_6_pack_1_oz_pouches",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8703,
+      "qwen_classification": "food package",
+      "qwen_reasoning": "The object appears to be a printed material, likely a product package or promotional card, featuring text, graphics, and an image of a food item (possibly a chocolate or pastry). There are visible elements such as a logo (pink cow-like figure), a green circular seal, and what looks like nutritional information or product description text. The object is presented at an angle, suggesting it's a flat, rectangular item. Given the visual elements, it is most likely a food product package or a promotional flyer for a food item."
+    },
+    {
+      "asset_name": "gso_Nips_Hard_Candy_Rich_Creamy_Butter_Rum_4_oz_1133_g",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8600,
+      "qwen_classification": "candy box",
+      "qwen_reasoning": "The object is a rectangular box with a brown and purple color scheme. The visible text includes the word \"Butter\" and an image of what appears to be caramel or toffee candies wrapped in foil. This packaging style is typical for confectionery products, specifically butter toffee or caramel candies. The shape and design strongly suggest it is a commercial candy box."
+    },
+    {
+      "asset_name": "gso_Netgear_Nighthawk_X6_AC3200_TriBand_Gigabit_Wireless_Router",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8611,
+      "qwen_classification": "router box",
+      "qwen_reasoning": "The image shows a product box with a clear depiction of a device on the front. The device has a sleek, modern design with multiple antennas, suggesting it is a wireless router. The box includes text that appears to describe the product's features, such as 'Wi-Fi 6' and 'Gigabit Ethernet', which are common specifications for modern routers. The overall presentation is typical of consumer electronics packaging. The object is clearly identifiable as a router box."
+    },
+    {
+      "asset_name": "gso_Nintendo_Wii_Party_U_with_Controller_Wii_U_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8694,
+      "qwen_classification": "gaming controller",
+      "qwen_reasoning": "The image shows a video game console controller, specifically a Nintendo Wii Remote (Wiimote), which is black and has a distinct shape with buttons and a pointer. It is displayed on the front of a product box for the game 'Wii Party'. The box also shows the Nintendo Wii logo and other game-related graphics. The controller is clearly identifiable as a gaming peripheral designed for the Nintendo Wii console."
+    },
+    {
+      "asset_name": "gso_Nightmare_Before_Christmas_Collectors_Edition_Operation",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8316,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The object appears to be a board game box, specifically for the game 'Operation'. This is identifiable by the prominent text 'OPERATION' written in large, stylized orange letters on the purple background. The artwork includes cartoonish imagery of a patient with a bandaged head and a medical theme, which is characteristic of the game's design. The box is shown at an angle, and the visible portion includes the game's title and some of its illustrative elements."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_CLI36_Remanufactured_Ink_Cartridge_TriColor",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8567,
+      "qwen_classification": "ink cartridge",
+      "qwen_reasoning": "The object is a rectangular package with a visible barcode, text, and branding. The design includes a red and white label with a circular logo, and the packaging appears to be for a consumable product, likely an ink cartridge or toner cartridge, given the common packaging style and the visible text that resembles product branding. The shape and labeling are consistent with printer consumables."
+    },
+    {
+      "asset_name": "gso_Now_Designs_Snack_Bags_Bicycle_2_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8454,
+      "qwen_classification": "notebook",
+      "qwen_reasoning": "The object appears to be a notebook or journal with a light blue cover. The cover features illustrations of bicycles in blue ink, with one large bicycle prominently displayed in the foreground and smaller bicycles in the background. The object has a visible spine and appears to be bound, consistent with a book or notebook. The style suggests it is a decorative or themed notebook, likely for writing or sketching."
+    },
+    {
+      "asset_name": "gso_Netgear_N750_Wireless_Dual_Band_Gigabit_Router",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8448,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a product box, specifically for a NETGEAR device. The brand name \"NETGEAR\" is clearly visible on the top surface. The box has a typical rectangular shape with a red and blue color scheme, and there is an image of a black electronic device on the front. The design and branding indicate it is packaging for a consumer electronics product, likely a router or modem, which is common for NETGEAR. The white areas are masks indicating the background has been removed, but the object itself is clearly identifiable as a product box."
+    },
+    {
+      "asset_name": "gso_Nestle_Nips_Hard_Candy_Peanut_Butter",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8391,
+      "qwen_classification": "chocolate bar wrapper",
+      "qwen_reasoning": "The image shows a close-up of a chocolate bar wrapper. The brand name \"Nips\" is prominently displayed in large, stylized lettering. Below it, the flavor is identified as \"Butter Parfait.\" The wrapper also includes descriptive text such as \"Rich & Creamy\" and \"Soft, Creamy Center,\" along with an image of the chocolate bar itself. The packaging design, including the color scheme and imagery, is typical of a confectionery product. The visible portion also indicates a quantity of \"30\" pieces, suggesting it is a multi-piece bar. All these elements confirm the object is a chocolate bar wrapper."
+    },
+    {
+      "asset_name": "gso_Ocedar_Snap_On_Dust_Pan_And_Brush_1_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8292,
+      "qwen_classification": "dustpan",
+      "qwen_reasoning": "The object shown is a dustpan, characterized by its shallow, wide, scoop-shaped body designed to collect debris, and a handle attached at the top for gripping and maneuvering. The shape and structure are consistent with standard household dustpans used for sweeping and collecting dust, dirt, or small particles. The object is isolated against a white background, confirming it is the sole focus."
+    },
+    {
+      "asset_name": "gso_Nintendo_Yoshi_Action_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8379,
+      "qwen_classification": "plush toy",
+      "qwen_reasoning": "The object is a stylized, cartoonish character with a green body, white belly, and orange feet. It has a distinct, rounded shape with large eyes and a small mouth, resembling a popular video game character. The design is consistent with the appearance of Yoshi, a well-known dinosaur-like creature from the Mario franchise. The object appears to be a 3D model or plush toy representation of Yoshi, given its smooth surfaces and simplified features."
+    },
+    {
+      "asset_name": "gso_Nickelodeon_Teenage_Mutant_Ninja_Turtles_Raphael",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8563,
+      "qwen_classification": "ninja turtle",
+      "qwen_reasoning": "The object is a stylized, cartoonish turtle character with a green shell, wearing a red bandana, and holding two sai weapons. This is a recognizable depiction of Raphael, one of the four Teenage Mutant Ninja Turtles. The character is shown in a dynamic, mid-action pose, consistent with the ninja turtle franchise. The segmented, cropped view isolates the character from its original context, but the distinct visual elements (shell, bandana, sai, color scheme) are unmistakable."
+    },
+    {
+      "asset_name": "gso_Nickelodeon_Teenage_Mutant_Ninja_Turtles_Michelangelo",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8379,
+      "qwen_classification": "cartoon character",
+      "qwen_reasoning": "The object appears to be a stylized, cartoonish figure with a green body, purple limbs, and a head that resembles a turtle or a similar creature. It has a somewhat blocky, low-polygon design, suggesting it might be a 3D model from a video game or animation. The figure is in a dynamic, possibly falling or tumbling pose, with limbs splayed out. The overall aesthetic is playful and non-realistic, consistent with a character model rather than a real-world object."
+    },
+    {
+      "asset_name": "gso_Nickelodeon_Teenage_Mutant_Ninja_Turtles_Leonardo",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8466,
+      "qwen_classification": "toy figure",
+      "qwen_reasoning": "The object is a stylized, green-skinned humanoid figure with a turtle-like appearance, wearing a purple belt and orange plastron. It is holding two swords, one in each hand, and appears to be in a dynamic, action-oriented pose. This is a recognizable character from the Teenage Mutant Ninja Turtles franchise, specifically Leonardo, who is known for wielding two katanas. The figure's design, including the mask, shell, and weapon style, matches the iconic depiction of this character."
+    },
+    {
+      "asset_name": "gso_Nikon_1_AW1_w11275mm_Lens_Silver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8764,
+      "qwen_classification": "camera lens",
+      "qwen_reasoning": "The object has a cylindrical shape with a textured, ribbed surface, which is typical of a camera lens barrel. There are visible rings and markings that suggest it is a photographic lens, including what appears to be a focus or zoom ring. The overall design, including the metallic or plastic finish and the way it tapers, is consistent with a standard interchangeable camera lens. The white background and cropping indicate it is isolated for identification, but the object's features are clearly identifiable as a camera lens."
+    },
+    {
+      "asset_name": "gso_Object_REmvBDJStub",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8480,
+      "qwen_classification": "Peter Pan hat",
+      "qwen_reasoning": "The object is a green, rounded cap with a single red feather attached to the top. This is a classic design associated with the character Peter Pan, specifically his iconic hat. The shape is that of a soft, rounded cap, not a hard helmet or structured hat. The red feather is a distinctive decorative element. This object is commonly recognized as Peter Pan's hat, a piece of costume or toy item."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_CLI_221BK_Ink_Cartridge_Black_2946B001",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8670,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a product box, specifically for an Office Depot brand item. The text \"CLI-251BK\" is visible, which is a model number commonly associated with printer cartridges. The design includes a graphic of a printer cartridge and branding elements typical of office supply packaging. The box is angled, showing its three-dimensional form, but the key identifying features are the text and product imagery."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_PG21XL_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8818,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a product box, specifically for an Office Depot brand item. The visible text includes \"Office De\" (likely \"Office Depot\"), a barcode, and a small image of a black rectangular device, possibly a printer or scanner. The red and white color scheme and the presence of a barcode are typical of retail packaging. The object is clearly a cardboard box used for packaging and selling a product."
+    },
+    {
+      "asset_name": "gso_OXO_Cookie_Spatula",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 7613,
+      "qwen_classification": "spatula",
+      "qwen_reasoning": "The object shown is a kitchen utensil with a black handle and a purple, flexible head. The head is flat and spatula-shaped, designed for spreading, scraping, or mixing. This is characteristic of a silicone spatula, commonly used in baking and cooking. The handle has a hole at the end, which is typical for hanging storage. The object's shape, material appearance (silicone head), and function are all consistent with a spatula."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_CL211XL_Remanufactured_Ink_Cartridge_TriColor",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8538,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The visible text \"Office DEPOT\" on the side of the object, along with the presence of a barcode and what appears to be product information, strongly suggests this is packaging for an office supply item. The design and layout are typical of retail product packaging. The object is likely a box or package for an item sold at Office Depot, such as paper, pens, or other office products. The red and white color scheme is also consistent with Office Depot's branding."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_9_Color_Ink_Ink_Cartridge_MK991_MK993",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8780,
+      "qwen_classification": "ink cartridge box",
+      "qwen_reasoning": "The object appears to be a rectangular box with a green and white color scheme. The visible text includes the word \"Series\" and \"compatible ink\" along with \"100% color\". This strongly suggests it is packaging for printer ink cartridges, specifically a compatible or generic replacement cartridge. The angled view and partial visibility of text are consistent with product packaging."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_11_Remanufactured_Ink_Cartridge_TriColor",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8563,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object is a product package, specifically for an Office Depot item. The visible text \"Office Depot\" confirms the brand. The packaging has a hang hole, typical for retail display, and shows a partial barcode and color-coded sections (green, purple, pink), suggesting it's for a consumable product like printer ink or toner cartridges. The shape and design are consistent with retail packaging for office supplies."
+    },
+    {
+      "asset_name": "gso_Nintendo_Mario_Action_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8396,
+      "qwen_classification": "video game character figurine",
+      "qwen_reasoning": "The object is a stylized, cartoonish figure with distinct features: a red cap with a white 'M' logo, a blue jumpsuit with red sleeves and yellow buttons, white gloves, and brown shoes. The pose is dynamic, with one arm raised and legs spread, suggesting movement or action. These are iconic visual elements of the video game character Mario, created by Nintendo. The object appears to be a 3D model or figurine of Mario, likely from a video game or merchandise, given the exaggerated proportions and smooth, rendered surfaces."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_2_Remanufactured_Ink_Cartridges_Color_Cyan_Magenta_Yellow_3_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8444,
+      "qwen_classification": "product package",
+      "qwen_reasoning": "The object is a cardboard package with a handle cutout, typical of retail packaging for office supplies. The visible text \"Office Depot\" confirms it is a product from that retailer. The shape, barcode, and design suggest it is packaging for an item like a printer cartridge or similar office consumable. The object is clearly identifiable as a product package."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_1_Remanufactured_Ink_Cartridge_TriColor",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8450,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and graphics. The visible text includes \"Office Depot\" and \"Series 1\", along with an image of a printer and colorful abstract graphics. This packaging style is typical for office supplies, specifically printer ink or toner cartridges. The box is angled, showing its front and side panels, and appears to be a commercial product package."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_9_Ink_Cartridge_Black_MK992",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8798,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a product box, specifically for an Office Depot brand item. The text on the box clearly reads \"Office Depot\" and \"Series 9\". There is also an image of a printer cartridge on the box, indicating that this is packaging for a printer ink or toner cartridge. The design and branding are consistent with office supply packaging."
+    },
+    {
+      "asset_name": "gso_Now_Designs_Bowl_Akita_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8509,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a round, shallow container with a decorative pattern. The pattern consists of repeating floral or starburst-like motifs in blue on a white background, with a thin yellow rim. This design is characteristic of ceramic tableware, specifically a bowl. The shape and decorative style suggest it is intended for serving food or holding items, such as cereal, soup, or salad. The craftsmanship and pattern are typical of traditional or artisanal ceramic bowls, possibly from a specific cultural or regional style (e.g., Japanese or Chinese porcelain)."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_564XL_Remanufactured_Ink_Cartridges_Color_Cyan_Magenta_Yellow_3_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8816,
+      "qwen_classification": "printer ink cartridge box",
+      "qwen_reasoning": "The object is a product box for printer ink cartridges. The branding \"Office Depot\" is visible, along with the model number \"HP 564XL\". The box features imagery of ink cartridges and colorful ink splatters, which is typical packaging for printer consumables. The design and text clearly indicate it is a retail package for printer ink."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_CL_41_Remanufactured_Ink_Cartridge_TriColor",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8707,
+      "qwen_classification": "product package",
+      "qwen_reasoning": "The object is a rectangular package with printed text and a barcode. The visible text includes \"Office Depot\" at the bottom, which is a well-known office supply retailer. The top section has a red banner with additional text, and there is a barcode on the right side. The overall appearance is consistent with a retail product package, likely for an office supply item such as paper, pens, or other stationery. The object is clearly a packaged product, not a standalone item."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_PG_240XL_Ink_Cartridge_Black_5206B001",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8621,
+      "qwen_classification": "ink cartridge packaging",
+      "qwen_reasoning": "The object is a white cardboard box with visible text that reads \"PG-240XL\" and \"Canon\". This is the packaging for a Canon printer ink cartridge. The box has a cut-out section revealing part of the black ink cartridge inside, which is consistent with how such products are packaged for retail. The model number \"PG-240XL\" is a specific ink cartridge model for Canon printers, confirming its identity."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_CLI_8Y_Ink_Cartridge_Yellow_0623B002",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8728,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and a yellow band. On the red side panel, the text \"CL-81\" and \"Canon\" is visible, which are common identifiers for Canon printer cartridges. The box shape, branding, and labeling are consistent with packaging for a printer consumable item. The yellow band is likely a visual indicator or part of the design for this specific model. Based on these features, it is clearly a printer cartridge box."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_PGI5BK_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8858,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular box with visible branding. The text \"Office Depot\" is clearly printed on the side, indicating it is packaging for an office supply product. The box has a barcode, typical for retail items, and a red and gray color scheme. The shape and labeling suggest it is a product box, likely for items such as paper, pens, or other office supplies. The perspective is angled, showing the top and side of the box."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_PGI35_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8615,
+      "qwen_classification": "office supply packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding visible. The text \"Office Depot\" is clearly printed on the side, indicating it is packaging for an office supply product. The pink label on the front likely indicates the product type or series. The design and branding are consistent with retail packaging for consumable office items such as printer ink, toner, or paper. The object is not a consumer electronic device, food item, or clothing, but rather commercial packaging."
+    },
+    {
+      "asset_name": "gso_Nintendo_2DS_Crimson_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8498,
+      "qwen_classification": "handheld gaming console",
+      "qwen_reasoning": "The object shown is a handheld gaming device with a distinctive dual-screen design. The top screen is larger and the bottom screen is smaller, both with a blueish tint, likely from the screen being on or reflecting light. On the left side, there are four circular buttons arranged in a diamond pattern, which is characteristic of Nintendo's control layout. The device has a black body with a red accent along the bottom edge. This specific design is unique to the Nintendo 2DS, a handheld gaming console released by Nintendo. The cropped view focuses on the upper-left portion of the device, showing part of the screens and the control buttons."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_11_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8706,
+      "qwen_classification": "ink cartridge packaging",
+      "qwen_reasoning": "The image shows a product box for an Office Depot brand ink cartridge. The packaging clearly displays the text 'Office DEPOT', 'compare to/comparar con Dell Series 11', and 'KX-TS1 JP461'. It also indicates that the cartridge is 'remanufactured'. The visual design includes an image of the black ink cartridge itself, along with a drop icon and green accents. This is a standard retail package for a printer consumable item."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_1_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8399,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object appears to be a product packaging box, likely for a cable or electronic accessory. The visible text includes \"Series\" and \"Pur\", which may be part of a product name like \"Pur Series\". The design features a gray background with a black cable image and a green accent strip at the bottom. The text \"For use with...\" suggests it's a compatible accessory. The overall shape and labeling are consistent with retail packaging for tech products."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_PGI22_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8578,
+      "qwen_classification": "printer ink cartridge packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and product information visible. The text \"Office Depot\" and \"PGI-220\" are clearly printed on the box. \"PGI-220\" is a known model number for a printer ink cartridge, specifically for Epson printers. The box also features an image of a printer cartridge and a red circular logo, which is typical packaging for printer consumables. The overall design and labeling strongly indicate this is packaging for a printer ink cartridge."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Dell_Series_5_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8810,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object is a white cardboard box with text printed on it. The visible text includes \"Office Depot\" in red, \"Series 5\" in black, and a barcode. The box has a green accent on the bottom right corner. This is clearly packaging for a product sold at Office Depot, likely office supplies or stationery, given the branding and the \"Series 5\" designation which often refers to product lines. The shape and labeling are consistent with retail product packaging."
+    },
+    {
+      "asset_name": "gso_OWL_SORTER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8688,
+      "qwen_classification": "toy car",
+      "qwen_reasoning": "The object appears to be a small, yellowish-brown toy vehicle, likely a baby or toddler's ride-on toy. It has a low, rounded body with a curved top, two small wheels at the front, and a handle or steering mechanism at the back. The design is simple and child-friendly, with a smooth, molded plastic appearance. The presence of a small orange and yellow detail on the back suggests it might be a decorative element or part of the steering mechanism. Based on its shape, size, and features, it is most likely a toy car or wagon designed for young children."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_932XL_Ink_Cartridge_Black_CN053A",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8840,
+      "qwen_classification": "toner cartridge box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed branding and product imagery. The visible text includes \"OFFICE DEPOT\" and \"932XL\", which are common identifiers for printer toner cartridges. The box also features an image of a toner cartridge and a blue and white color scheme typical of Office Depot packaging. This is clearly a product packaging box for a printer consumable."
+    },
+    {
+      "asset_name": "gso_Office_Depot_Canon_CLI_8CMY_Remanufactured_Ink_Cartridges_Color_Cyan_Magenta_Yellow_3_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8645,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The image shows a cropped view of what appears to be a product package or box. It has a white background with colorful abstract graphics (yellow, blue, pink) and text. The pink section on the right contains bold text that appears to be \"1911\" and smaller text below it. The overall design suggests it is packaging for a consumer product, possibly a cosmetic, skincare, or beauty item, given the aesthetic and the presence of what looks like product branding. The object is clearly a physical package, not a digital interface or natural object."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_61Tricolor_Ink_Cartridge",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8862,
+      "qwen_classification": "ink cartridge package",
+      "qwen_reasoning": "The image shows a product package with the 'Office Depot' logo prominently displayed. Below the logo, the text 'HP 61' is visible, indicating it is a compatible ink cartridge for HP printers. The packaging also features an image of the actual ink cartridge, which is purple and magenta in color. This is a standard retail box for a printer ink cartridge, specifically designed for use with HP printers and sold through Office Depot."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_96_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8549,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a product box, specifically for an HP printer cartridge. The visible text includes \"HP 96\" and \"Office Depot\", indicating it is a compatible or branded ink cartridge for HP printers. The box has a typical rectangular shape with branding and product information printed on it. The partial view shows a blue logo (likely HP) and a black-and-white graphic design, consistent with printer cartridge packaging."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_75_Remanufactured_Ink_Cartridge_TriColor",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8614,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a rectangular box with a clean, modern design. It features a color gradient along one edge, transitioning from red to yellow to blue, which is typical for printer ink or toner cartridges. The box has a logo or emblem on the lower right side, and there are some text markings visible on the side, which are common on packaging for consumable printer supplies. The overall shape and labeling strongly suggest it is a printer cartridge package."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Birdie_Sidekick_Backpack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8483,
+      "qwen_classification": "baby carrier",
+      "qwen_reasoning": "The object appears to be a baby carrier or sling, characterized by its fabric construction, the presence of straps (one black strap is visible), and the patterned, lightweight-looking material. The design with colorful patterns is typical for baby carriers intended for infants. The shape suggests it is designed to wrap around a wearer's body to hold a baby securely. The black strap and the patterned fabric are consistent with common baby carrier designs."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_920XL_920_High_Yield_Black_and_Standard_CMY_Color_Ink_Cartridges",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8794,
+      "qwen_classification": "printer ink cartridge box",
+      "qwen_reasoning": "The object is a rectangular box with printed text and color indicators. The visible text includes \"OfficeJet\" and \"920XL\", which are common branding and model identifiers for printer ink cartridges. The presence of color-coded stripes (cyan, magenta, yellow) further supports that this is packaging for a multi-color ink cartridge set. The box has a handle cutout, typical for product packaging. This is clearly a printer ink cartridge packaging box."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_71_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8793,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and product information visible. The text \"Office DEPOT\" is clearly printed in red, indicating it is a product package from that retailer. The number \"HP 701\" is also visible, which likely refers to a product model or part number (possibly for an ink cartridge or printer consumable). The box has a blue and white color scheme with an image of a printer or printer-related component. This is a standard retail packaging for office supplies."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_564XL_Ink_Cartridge_Black_CN684WN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8980,
+      "qwen_classification": "ink cartridge packaging",
+      "qwen_reasoning": "The object is a product box, specifically for an HP 564XL ink cartridge. This is evident from the visible text \"HP 564XL\" and the \"Office Depot\" branding on the packaging. The box has a typical rectangular shape with printed graphics and text, which is characteristic of consumer product packaging. The design includes a stylized image of an ink cartridge and a blue and white color scheme, consistent with printer ink packaging. The object is clearly identifiable as a retail package for a printer consumable item."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_98_Remanufactured_Ink_Cartridge_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8648,
+      "qwen_classification": "printer cartridge box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a hanging hole on the left side, typical of retail packaging. The visible text \"Office Depot\" indicates it is packaging for an office supply item. The design includes a blue and white color scheme with a barcode and product information. This is characteristic of packaging for a printer cartridge or similar consumable office product. The shape and features strongly suggest it is a product box for an ink or toner cartridge, commonly sold at Office Depot."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Dinosaur_Land_Lunch_Box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8690,
+      "qwen_classification": "lunch bag",
+      "qwen_reasoning": "The object is a rectangular, soft-sided container with a zipper closure, featuring a colorful pattern of cartoon dinosaurs and bones on a light blue background. This design and form factor are characteristic of a children's lunch bag or school bag. The presence of a zipper and the fabric-like appearance suggest it is designed for carrying items, likely food or school supplies, for a child. The dinosaur theme further supports its intended use for young children."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Birdie_Pack_n_Snack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8662,
+      "qwen_classification": "backpack",
+      "qwen_reasoning": "The object is a light blue, soft-sided bag with rounded corners and a zipper closure. It features a playful pattern of cartoon animals (such as owls, birds, and possibly a cat) and small decorative elements like houses and numbers. The shape and design suggest it is intended for children. The presence of wheels at the bottom indicates it is a rolling backpack or school bag, designed for easy transport. The overall appearance is consistent with a children's backpack or rolling suitcase."
+    },
+    {
+      "asset_name": "gso_Now_Designs_Dish_Towel_Mojave_18_x_28",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8078,
+      "qwen_classification": "scarf",
+      "qwen_reasoning": "The object is a rectangular, fabric item with a solid olive-green color on most of its surface and a decorative striped pattern along one edge. The stripes include multiple colors such as orange, red, yellow, and green. The texture appears woven, suggesting it is made of cloth. Given its shape, color, and pattern, it is most likely a textile item such as a scarf, a towel, or a decorative cloth. However, without additional context or views, it is difficult to definitively classify it as one specific type of textile item. The most plausible classification is a scarf, as it matches the typical dimensions and appearance of a scarf, but other possibilities like a small towel or decorative cloth cannot be ruled out with certainty."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_950XL_Ink_Cartridge_Black_CN045AN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8704,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object appears to be a rectangular cardboard box, likely for packaging or shipping. It has a beige or light brown color with some blue and possibly other colored markings on its side. The shape is consistent with a standard shipping or product box, and the visible edges and corners suggest it is a rigid container. The markings could be labels, barcodes, or branding, which are common on such boxes. Given the context and appearance, it is most likely a generic cardboard box used for commercial or consumer purposes."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Butterfly_Garden_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8255,
+      "qwen_classification": "roll of decorative paper",
+      "qwen_reasoning": "The object is a cylindrical item with a pattern of colorful butterflies and small flowers on a light background. The shape and pattern suggest it is a decorative or functional rolled-up item, such as a roll of wrapping paper, gift wrap, or possibly a decorative fabric roll. The presence of a small blue and white label or tag at one end further supports it being a packaged product. Given the context and appearance, it is most likely a roll of decorative paper or fabric."
+    },
+    {
+      "asset_name": "gso_Office_Depot_HP_74XL75_Remanufactured_Ink_Cartridges_BlackTriColor_2_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8964,
+      "qwen_classification": "office supply box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and graphics. The most prominent text visible is \"Office DEPOT\" in red, which is the name of a retail store. There is also a barcode, product information, and a small logo. The box appears to be packaging for an office supply item, likely a printer cartridge or similar consumable, given the context of the brand and typical product packaging. The top of the box has a cut-out handle, suggesting it's designed for carrying. The overall shape and labeling are consistent with retail packaging for office products."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Game_On_Munch_n_Lunch",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8894,
+      "qwen_classification": "tablecloth",
+      "qwen_reasoning": "The object is a folded piece of fabric with a colorful pattern. The pattern includes various sports-related items such as basketballs, soccer balls, baseball bats, and pennants. The edges of the fabric are trimmed with a solid purple border. This appearance is typical of a sports-themed party tablecloth or a decorative fabric item designed for children's events or sports-themed gatherings."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Birdie_Lunch_Box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8610,
+      "qwen_classification": "lunch bag",
+      "qwen_reasoning": "The object is a rectangular, soft-sided container with a zipper closure, featuring a light-colored fabric with a playful pattern of cartoon animals (owls, birds) and other whimsical designs. It has a small, dark logo or tag on one side. This design and form factor are characteristic of a children's lunch bag or insulated lunchbox, commonly used to carry food and drinks to school or daycare. The material appears to be fabric, and the construction suggests it is designed for portability and durability."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Game_On_Lunch_Box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8498,
+      "qwen_classification": "lunchbox",
+      "qwen_reasoning": "The object is a rectangular, soft-sided container with a zipper closure, decorated with a colorful pattern of sports equipment such as basketballs, soccer balls, baseballs, and bats. This design and shape are characteristic of a lunchbox or a small storage bag intended for children, often used to carry food or personal items. The material appears to be fabric, and the zipper suggests it is designed for easy opening and closing."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Birdie_Munch_n_Lunch",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8681,
+      "qwen_classification": "pouch",
+      "qwen_reasoning": "The object is a light blue, rectangular item with a pattern of colorful cartoon-like shapes including houses, birds, and flowers. It appears to be made of a flexible material, possibly plastic or fabric, and has a slightly crumpled or folded appearance. The design and form suggest it is a container or pouch, likely for storing small items. The pattern and color scheme are typical of children's products, such as a lunchbox, toy storage bag, or a small cosmetic bag. The object is not a standard container like a water bottle or a shoe, but rather a soft, patterned pouch."
+    },
+    {
+      "asset_name": "gso_PEPSI_NEXT_CACRV",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8358,
+      "qwen_classification": "soda can",
+      "qwen_reasoning": "The object displays the iconic Pepsi logo, which consists of a red, white, and blue circular design. The blue background and the partial text visible (\"60 calories per can\") are characteristic of Pepsi's product packaging, specifically for a beverage can. The shape and branding strongly indicate it is a Pepsi soda can."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Dinosaur_Land_Sidekick_Backpack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8723,
+      "qwen_classification": "travel bag",
+      "qwen_reasoning": "The object is a soft-sided, rectangular bag with a zipper closure and a handle on top. The top portion has a light blue background with a playful pattern of green dinosaurs and other colorful shapes, while the bottom portion is solid black. The design and structure suggest it is a travel bag or a duffel-style bag, likely intended for children or casual use given the dinosaur motif. The presence of a handle and what appears to be a shoulder strap attachment point (visible on the side) supports its classification as a bag designed for carrying items."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Mermaids_Pack_n_Snack_Backpack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8592,
+      "qwen_classification": "backpack",
+      "qwen_reasoning": "The object is a backpack, identifiable by its distinct shape, straps, and the presence of a brand label ('wildkin') on the back panel. The visible features include padded shoulder straps, a central back panel, and a decorative pattern on the top and sides, which is typical for children's backpacks. The object is clearly segmented from its surroundings, and the non-white regions represent the backpack itself."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Dinosaur_Land_Pack_n_Snack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8732,
+      "qwen_classification": "children's rolling suitcase",
+      "qwen_reasoning": "The object is a soft-sided, rectangular container with a zipper closure and a handle on top. It features a colorful, cartoonish pattern with dinosaurs and other playful designs, suggesting it is intended for children. The shape and design are consistent with a portable, collapsible storage bag or a small travel case, often used for toys, snacks, or personal items. The presence of wheels or a rolling base (implied by the black base visible at the bottom) indicates it is designed for mobility. This matches the description of a children's rolling suitcase or a toy storage bag."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Robots_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8255,
+      "qwen_classification": "pencil case",
+      "qwen_reasoning": "The object is a blue, elongated item with a zipper on one side and colorful cartoon-like graphics on its surface. The shape and features (zipper, fabric-like appearance, decorative pattern) are characteristic of a pencil case or pencil pouch, commonly used to store writing utensils and school supplies. The graphics appear to be playful, possibly featuring cartoon characters or vehicles, which is typical for children's stationery items."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Dinosaur_Land_Munch_n_Lunch",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8795,
+      "qwen_classification": "bib",
+      "qwen_reasoning": "The object appears to be a soft, fabric item with a pattern of cartoon dinosaurs on a light-colored background. It has a folded or collapsed shape with visible seams and a purple trim along the edges. The material looks like cotton or a similar textile, commonly used for children's items. The overall form and pattern suggest it is likely a children's accessory, such as a bib, a small blanket, or a play mat. Given the context and appearance, it is most likely a bib, as it has the typical shape and fold of a bib, and the dinosaur pattern is common for children's bibs."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Trains_Planes_Trucks_Bogo_Backpack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8829,
+      "qwen_classification": "backpack",
+      "qwen_reasoning": "The object appears to be a backpack, identifiable by its shape, straps, and compartments. The visible portion shows a light blue fabric with a colorful pattern of cartoon-like vehicles (cars, trucks, etc.), suggesting it is designed for children. There are zippers and a black panel, which are common features of backpacks. The object is cropped and viewed from an angle, but the structural elements are consistent with a backpack."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Butterfly_Garden_Munch_n_Lunch_Bag",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8490,
+      "qwen_classification": "cushion",
+      "qwen_reasoning": "The object appears to be a soft, fabric-covered item with a pattern of colorful butterflies and small flowers on a light background. Its shape is somewhat rectangular but appears to be folded or rolled, suggesting it is flexible. The material looks like cloth, and the design is typical of children's items. Given the pattern and the way it is folded, it is most likely a small cushion, a toy, or a storage pouch rather than a rigid object. The folds and creases indicate it is pliable and not a hard container or electronic device. Without more context, the most plausible classification is a soft fabric item, possibly a cushion or a toy."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Game_On_Pack_n_Snack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8674,
+      "qwen_classification": "backpack",
+      "qwen_reasoning": "The object is a light blue, soft-looking item with a pattern of sports-related graphics including basketballs, soccer balls, baseballs, and pennants. It has a contoured shape with black straps or handles on the sides, suggesting it is designed to be carried or worn. The overall appearance is consistent with a sports-themed backpack or a small duffel bag, commonly used for carrying sports equipment or personal items. The segmented view shows multiple panels, which is typical for such bags."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Trains_Planes_Trucks_Munch_n_Lunch_Bag",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8661,
+      "qwen_classification": "tote bag",
+      "qwen_reasoning": "The object appears to be a folded fabric item, likely a tote bag or a small blanket, with a colorful pattern featuring cartoon-style vehicles such as cars, airplanes, and boats. The material looks soft and pliable, consistent with textile products. The way it is folded and the visible seams suggest it is a manufactured item designed for carrying or use as a blanket. The pattern and style are typical of children's items."
+    },
+    {
+      "asset_name": "gso_Paul_Frank_Dot_Lunch_Box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8546,
+      "qwen_classification": "lunchbox",
+      "qwen_reasoning": "The object is a small, rectangular, soft-sided bag with a pattern of cartoon monkey faces (Paul Frank brand) on a pink background. It has a red zipper and a red handle, suggesting it is designed for carrying small items. The shape and features are consistent with a lunchbox or a small cosmetic bag."
+    },
+    {
+      "asset_name": "gso_Ortho_Forward_Facing",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8660,
+      "qwen_classification": "plush toy",
+      "qwen_reasoning": "The object appears to be a plush toy, specifically resembling a giraffe. It has a yellowish-brown body with reddish-brown spots, which is characteristic of a giraffe's pattern. The visible portion includes part of the torso and legs, with a small white tag or piece of fabric at the top, likely part of the toy's construction. The texture and shape suggest it is a soft, stuffed toy rather than a real animal or inanimate object."
+    },
+    {
+      "asset_name": "gso_PHEEHAN_RUN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8237,
+      "qwen_classification": "athletic shoe",
+      "qwen_reasoning": "The object appears to be a piece of athletic footwear, specifically a shoe. It has a sleek, aerodynamic design with a curved upper and a visible sole. The color scheme is predominantly black with white and purple accents, which is common in performance or fashion-oriented athletic shoes. The shape and contours suggest it is designed for activities like running or training. The presence of what looks like a brand logo (though partially obscured) further supports that this is a branded athletic shoe."
+    },
+    {
+      "asset_name": "gso_Pepsi_Caffeine_Free_Diet_12_CT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8560,
+      "qwen_classification": "beverage box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with the Pepsi logo prominently displayed on its side. The logo consists of a red, white, and blue circular design with the word 'pepsi' written in lowercase letters. The box appears to be a product package, likely for a beverage or snack item associated with the Pepsi brand. The design and branding are unmistakable and clearly identify it as a Pepsi product package."
+    },
+    {
+      "asset_name": "gso_Organic_Whey_Protein_Unflavored",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8663,
+      "qwen_classification": "supplement container",
+      "qwen_reasoning": "The object is a white plastic container with a label that has text and a barcode. The shape is cylindrical with a screw-on lid, typical of supplement or powder containers. The label is yellowish with blue borders and contains printed information, which is common for nutritional products or pharmaceuticals. The object is not a bottle, jar, or can in the traditional sense, but rather a specific type of container designed for storing powdered or granular substances, often used for vitamins, protein powder, or other dietary supplements."
+    },
+    {
+      "asset_name": "gso_Organic_Whey_Protein_Vanilla",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8661,
+      "qwen_classification": "protein powder container",
+      "qwen_reasoning": "The object is a cylindrical container with a white lid and a label that prominently displays the text 'WHEY PROTEIN'. The label also includes the brand name 'Jarrow Formulas' and indicates a net weight of '16 oz (454 g)'. The design and labeling are characteristic of a dietary supplement container, specifically for whey protein powder, which is commonly sold in such jars or tubs. The shape, labeling, and context strongly suggest it is a protein powder supplement container."
+    },
+    {
+      "asset_name": "gso_Pass_The_Popcorn_Movie_Guessing_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8735,
+      "qwen_classification": "popcorn box",
+      "qwen_reasoning": "The object is a rectangular box with a pink and white striped design. It features the text \"PASTEL POPCORN\" in a circular logo, along with a small image of popcorn kernels. The overall appearance and branding strongly suggest it is a snack box, specifically for popcorn. The design elements (pastel colors, popcorn imagery) are typical for packaged snacks, particularly those marketed as fun or sweet treats."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Health_Weight_Management_Supplements",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8923,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a rectangular cardboard box, likely for shipping or packaging. It has visible features such as a barcode on one side and printed text or graphics on the top and side panels. The box appears to be sealed and is presented at an angle, showing multiple faces. These characteristics are typical of standard shipping or product packaging boxes."
+    },
+    {
+      "asset_name": "gso_Ortho_Forward_Facing_CkAW6rL25xH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8445,
+      "qwen_classification": "motorcycle helmet",
+      "qwen_reasoning": "The object is a helmet with a glossy black finish and decorative green and white swirl patterns. It has a rounded, aerodynamic shape typical of motorcycle helmets. Visible features include a chin guard, a visor area (though not fully visible), and what appears to be a ventilation port or adjustment knob on the side. The design and structure are consistent with a half-face or open-face motorcycle helmet, often used for street riding or racing. The white background is masking the surrounding environment, focusing attention on the helmet itself."
+    },
+    {
+      "asset_name": "gso_Pepsi_Cola_Wild_Cherry_Diet_12_12_fl_oz_355_ml_cans_144_fl_oz_426_lt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8292,
+      "qwen_classification": "beverage pack",
+      "qwen_reasoning": "The object is a red, rectangular container with the distinctive Pepsi logo (a circular design with red, white, and blue segments) visible on its surface. The word \"Pepsi\" is also partially visible in white text. This branding and shape are characteristic of a Pepsi product container, most likely a six-pack or multi-pack of Pepsi soda cans. The object appears to be a cardboard or plastic outer packaging for beverages."
+    },
+    {
+      "asset_name": "gso_Ortho_Forward_Facing_3Q6J2oKJD92",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8539,
+      "qwen_classification": "stuffed animal",
+      "qwen_reasoning": "The object appears to be a stylized, low-polygon 3D model of an animal, likely a dog or a similar quadruped. It has a rounded body, four limbs, a tail, and a head with what appears to be an ear. The texture and shape suggest it is a plush toy or a simplified digital representation of an animal. The object is shown from a side angle, with the head turned slightly away from the viewer. The overall form is consistent with a stuffed animal or a cartoonish animal figure."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Cold_Plasma",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8941,
+      "qwen_classification": "cosmetic product box",
+      "qwen_reasoning": "The object is a dark-colored rectangular box with a minimalist design. On one side, there is a line drawing of a woman's face, suggesting it is packaging for a beauty or skincare product. The other visible side has text and a barcode, which are typical features of commercial product packaging. The overall appearance is consistent with a cosmetic product box, such as for a face mask or skincare treatment."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Face_Finishing_Moisturizer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 9135,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a white, rectangular box with a small brown label and a star-shaped emblem on its side. The shape and features are consistent with a product packaging box, likely for a consumer item. The label and star suggest branding or product identification, but the specific product is not identifiable from this view. Given the context and appearance, it is most likely a generic product box."
+    },
+    {
+      "asset_name": "gso_PUNCH_DROP_TjicLPMqLvz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8900,
+      "qwen_classification": "ball drop toy",
+      "qwen_reasoning": "The object is a wooden box with a circular opening on the front and a lid that is partially open. Inside the box, there are three colored balls (blue, red, and green) and a wooden mallet or hammer. This setup is characteristic of a classic children's toy known as a 'ball drop' or 'ball puzzle' game, where the goal is to use the mallet to push the balls into the circular opening. The construction and components are consistent with this type of educational toy."
+    },
+    {
+      "asset_name": "gso_Orbit_Bubblemint_Mini_Bottle_6_ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8490,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a pink and white color scheme. It has printed graphics and text, including what appears to be a logo or brand name (possibly 'SUGA' or similar) and some smaller text on the top flap. The box has a distinct shape with visible flaps and seams, typical of packaging for consumer goods. The design suggests it could be for a product like candy, snacks, or a small toy, but the specific contents are not identifiable from the image. The object is clearly a packaged item, not a functional device or tool."
+    },
+    {
+      "asset_name": "gso_Ortho_Forward_Facing_QCaor9ImJ2G",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8585,
+      "qwen_classification": "plush koala toy",
+      "qwen_reasoning": "The object is a plush toy shaped like a koala. It has features characteristic of a koala: a rounded head, large ears (one of which is visible and has a white interior), a black nose, and dark eyes. The body is made of gray, fluffy fabric, and the limbs are positioned in a relaxed, stuffed-animal manner. The texture and construction indicate it is a soft, stuffed toy rather than a live animal or a rigid object. The white background confirms it is isolated for viewing, but the object's form is clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Paper_Mario_Sticker_Star_Nintendo_3DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8328,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The image shows the back of a video game case. It features colorful graphics, text, and logos typical of a video game box. The visible text includes \"Stick the World Together!\" and \"Get Started,\" which are common marketing phrases for games. There are also small screenshots of gameplay, a Nintendo logo, and a rating label (E for Everyone). The overall design and layout are consistent with a physical video game cartridge or disc case for a console like the Nintendo Wii or similar system."
+    },
+    {
+      "asset_name": "gso_Perricoen_MD_No_Concealer_Concealer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8497,
+      "qwen_classification": "skincare product box",
+      "qwen_reasoning": "The object is a rectangular box with text printed on its surface. The visible text reads \"No Makeup Skincare\" and \"Puritan's Pride\" at the top. The box has a solid, muted orange or tan color and appears to be a product packaging for skincare items. The shape and labeling are consistent with commercial product boxes, specifically for cosmetics or personal care products. The perspective shows a three-dimensional view of the box, suggesting it is a physical container for products."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Neuropeptide_Facial_Conformer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8361,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a dark brown rectangular box with text and a barcode visible on its side. The presence of printed text and a barcode strongly suggests it is a product packaging box, likely for a consumer item. The shape and labeling are typical of retail packaging for goods such as cosmetics, electronics, or food products. However, without visible branding or specific product details, a more precise classification is not possible."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Hypoallergenic_Gentle_Cleanser",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8584,
+      "qwen_classification": "box",
+      "qwen_reasoning": "The object appears to be a rectangular, beige-colored box with text printed on its side. The shape and appearance are consistent with a product packaging box, likely for a consumer item. There is a small, detached piece near the bottom, which could be a label or part of the packaging. The object lacks distinctive features to identify it as a specific product, but its form strongly suggests it is a generic box."
+    },
+    {
+      "asset_name": "gso_Pepsi_Max_Cola_Zero_Calorie_12_12_fl_oz_355_ml_cans_144_fl_oz_426_lt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8464,
+      "qwen_classification": "beverage case",
+      "qwen_reasoning": "The object is a cardboard box with branding for 'Pepsi Max'. The iconic Pepsi logo (red, white, and blue circular design) is clearly visible, along with the text 'Pepsi MAX'. The box also indicates it contains 12 cans, as shown by the '12' and '12x330ml' text. This is a standard beverage case for canned soda. The box appears to be slightly worn or dirty, but the branding is still legible."
+    },
+    {
+      "asset_name": "gso_Paint_Maker",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8679,
+      "qwen_classification": "toy box",
+      "qwen_reasoning": "The object appears to be a rectangular package, likely for a children's product, given the bright colors and cartoon-like illustrations visible on its surface. The top portion shows a yellow background with text and graphics, including what looks like a barcode and product information. The bottom portion shows a darker, possibly purple or blue, section with more illustrations. The overall shape and design suggest it is a retail box for a toy or art supply, such as crayons or coloring books, commonly found in stores. The perspective is angled, showing the top and side of the package."
+    },
+    {
+      "asset_name": "gso_PEEKABOO_ROLLER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8680,
+      "qwen_classification": "ceremonial bell",
+      "qwen_reasoning": "The object is a cylindrical, golden-colored item with a red button or knob on its side and a red spiral or swirl design on its surface. There is also a small square emblem or seal with characters on one side. The overall shape and features suggest it is a type of traditional Japanese instrument, specifically a \"kane\" (bell) or a \"kane\"-like object, often used in ceremonial or decorative contexts. The red button may be a mechanism for striking or activating the bell, and the spiral design could be decorative or symbolic. The emblem with characters further supports its cultural or ceremonial origin."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_AcylGlutathione_Eye_Lid_Serum",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8986,
+      "qwen_classification": "cosmetic product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and graphics. The visible text includes \"Anti-Cellulite Serum\" and \"100 ml (3.4 fl.oz.)\", indicating it is packaging for a cosmetic or skincare product. The design features a dark purple/blue color scheme with a stylized image of a serum bottle. The box is angled, showing multiple sides, but the primary focus is on the product information. This is clearly commercial packaging for a beauty product."
+    },
+    {
+      "asset_name": "gso_Pennington_Electric_Pot_Cabana_4",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8544,
+      "qwen_classification": "flower pot",
+      "qwen_reasoning": "The object is a cylindrical container with a wide opening and a slightly flared rim. It has a uniform yellow color and appears to be made of a smooth, possibly ceramic or plastic material. The shape and form are consistent with a small pot or cup, commonly used for holding plants or serving beverages. The absence of any handles, spouts, or other features suggests it is not a specialized vessel like a mug or a watering can. Given its simple, utilitarian design, it most closely resembles a small flower pot or a drinking cup."
+    },
+    {
+      "asset_name": "gso_Pepsi_Cola_Caffeine_Free_12_12_fl_oz_355_ml_cans_144_fl_oz_426_lt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8522,
+      "qwen_classification": "pepsi box",
+      "qwen_reasoning": "The object is a cardboard box with the Pepsi logo prominently displayed on its side. The logo consists of a circular design with red, white, and blue segments, and the word \"Pepsi\" is written in its distinctive lowercase font. The box appears to be a standard rectangular cardboard container, likely for packaging Pepsi products such as cans or bottles. The perspective shows the top and one side of the box, with the logo visible on the side facing the viewer. The design and branding are unmistakably associated with the Pepsi beverage company."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_No_Foundation_Foundation_No_1",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8539,
+      "qwen_classification": "cosmetic product box",
+      "qwen_reasoning": "The object is a rectangular box with text printed on it. The visible text includes \"No Makeup\" and \"Shade\". This strongly suggests it is a cosmetic product, likely a foundation or concealer, given the context of \"No Makeup\" and \"Shade\". The design is minimalist and clean, typical of cosmetic packaging. The object appears to be a product box for a makeup item."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Neuropeptide_Firming_Moisturizer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8826,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a brown cardboard box with printed text and a barcode visible on its side. The text appears to be in multiple lines, likely containing product information, ingredients, or usage instructions. The presence of a barcode suggests it is a commercial product package. The box has a standard rectangular shape with visible edges and corners, typical of packaging for consumer goods. The material and design are consistent with product packaging for items like food, cosmetics, or household products."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Firming_Neck_Therapy_Treatment",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 9009,
+      "qwen_classification": "printed page",
+      "qwen_reasoning": "The image shows a portion of a printed document or booklet, specifically a section titled 'Product Benefits' and 'Clinical Studies'. The text is legible and discusses features like 'highly advanced and potent' formulation for 'neck area concerns' and 'wrinkle skin'. The layout, typography, and content are characteristic of a product information sheet or packaging insert for a cosmetic or skincare product. The object is clearly a printed page or leaflet, not a physical product like a bottle or tube."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_AcylGlutathione_Deep_Crease_Serum",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 9098,
+      "qwen_classification": "facial massage tool packaging",
+      "qwen_reasoning": "The object is a rectangular box with a dark brown color. On its top surface, there is a line drawing of a human face with eyes closed, and vertical lines suggesting facial features or perhaps a massage tool. The box also has text printed on it, though the text is not legible in the image. This design is characteristic of a product packaging for facial massage tools, such as gua sha or jade rollers, which are often marketed with imagery of relaxation and facial care. The overall presentation suggests it is a consumer product, likely for beauty or wellness purposes."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Hypoallergenic_Firming_Eye_Cream_05_oz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8914,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a white, rectangular box with printed text and a barcode. The visible text includes phrases like \"Decades of Research\" and \"Proprietary Technology,\" along with a product code \"MF6008.\" These elements are typical of commercial packaging for consumer goods, such as a product box for cosmetics, supplements, or electronics. The barcode and product code further confirm it is packaging designed for retail distribution. The object's shape and labeling are consistent with standard product boxes."
+    },
+    {
+      "asset_name": "gso_PINEAPPLE_MARACA_6_PCSSET",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8206,
+      "qwen_classification": "children's toy",
+      "qwen_reasoning": "The object is a brightly colored, rounded toy with a yellow upper section featuring an orange grid pattern and three small black dots. The lower section is green and shaped like a leaf or a stylized base. The text \"plantoys\" is visible on the green part, indicating it is a product from the brand Plant Toys. The design and branding suggest it is a children's toy, likely intended for sensory play or as a teething toy due to its soft, rounded appearance. The grid pattern and dots may be for tactile stimulation or for attaching other components. Based on the visual evidence and branding, this is a children's sensory or teething toy."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_OVM",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8677,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and imagery. The visible text includes \"Papaya 3D\" and \"CAYA\", suggesting it is packaging for a product. The imagery on the box shows a small, round container, likely a jar or bottle, which is typical for cosmetic or skincare products. The overall design and context strongly indicate this is product packaging, specifically for a beauty or skincare item."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_No_Foundation_Serum",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8627,
+      "qwen_classification": "teapot box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with a printed image of a teapot on its side. The box appears to be packaging for a teapot, as the image on the box is clearly a teapot. The design suggests it is a product box, likely for a ceramic or porcelain teapot, given the style of the illustration. The box has a barcode on one side, which is typical for retail packaging. The overall shape and labeling are consistent with consumer product packaging."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_No_Lipstick_Lipstick",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8658,
+      "qwen_classification": "cosmetic product box",
+      "qwen_reasoning": "The object is a rectangular box with a gradient pink and white color scheme. Text is visible on the side, including the words \"No Makeup\" and \"Skincare\". This indicates it is a product packaging, likely for a cosmetic or skincare item. The design and text suggest it is a commercial product box, possibly for a makeup remover or skincare product that emphasizes a \"no makeup\" look. The shape and labeling are consistent with typical cosmetic product packaging."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Chia_Serum",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8580,
+      "qwen_classification": "medical product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and branding. The visible text includes \"Peritoneal MD\" and \"Peritoneal Dialysis Solutions,\" indicating it is a medical product container. The orange label on the side contains additional information, likely product details or usage instructions. The box's shape and labeling are consistent with pharmaceutical or medical supply packaging. The presence of small black symbols (possibly arrows or icons) on the top and side suggests it may be part of a larger packaging system or have specific handling instructions. Based on the text and context, this is clearly a product box for a medical device or solution."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Face_Finishing_Moisturizer_4_oz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8810,
+      "qwen_classification": "pharmaceutical box",
+      "qwen_reasoning": "The object is a rectangular box with printed text and a logo. The visible text includes \"Rx2\" and \"Control\", which are common markings on pharmaceutical packaging. The box has a clean, clinical appearance typical of medication containers. The angled view and the way the text is oriented suggest it is a product box, likely for a prescription drug or medical device. The presence of \"Rx2\" strongly indicates it is related to pharmaceuticals, as \"Rx\" is the standard abbreviation for prescription medication. The box appears to be made of cardboard or similar material, consistent with packaging for pharmaceutical products."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_High_Potency_Evening_Repair",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8699,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular, light-colored box with printed text and a small logo or emblem on the top surface. The text is too small and blurry to read clearly, but the overall shape and presentation suggest it is a product packaging box. The clean, minimalist design and the presence of branding elements are typical of consumer goods packaging. Given the context and appearance, it is most likely a box for a consumer product, such as a cosmetic item, electronic device accessory, or similar packaged good. However, without clearer text or more context, a specific product type cannot be confidently identified."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Skin_Clear_Supplements",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8634,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a white, rectangular box with visible seams and flaps, suggesting it is a cardboard or paperboard container. There are printed labels or text on its surface, and a small red and yellow circular mark on one side, which may indicate branding or product information. The shape and construction are typical of a shipping or storage box, possibly for office supplies or small products. The object appears to be a standard corrugated cardboard box, commonly used for packaging and shipping."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Super_Berry_Powder_with_Acai_Supplements",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8738,
+      "qwen_classification": "supplement container",
+      "qwen_reasoning": "The image shows a cropped view of a white rectangular object with text and vertical lines. The text clearly reads \"Supplement Facts\" on the left side, which is a standard label found on dietary supplement containers. The layout with vertical lines suggests a nutritional facts panel. This is characteristic of the back or side of a supplement bottle or box. The object is clearly identifiable as part of a dietary supplement packaging."
+    },
+    {
+      "asset_name": "gso_Pet_Dophilus_powder",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8370,
+      "qwen_classification": "probiotic supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a yellow label. The label has text and imagery, including what appears to be the word 'Lactobacillus' and images of probiotic capsules. This is characteristic of a dietary supplement or probiotic product, commonly sold in bottles like this. The shape, cap, and labeling are consistent with consumer health products."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Nutritive_Cleanser",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8531,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular, beige-colored box with visible text and markings on its surface. The shape and appearance are consistent with packaging for a product, such as a consumer electronic device, a book, or a cosmetic item. The text on the box is too small and indistinct to identify the specific product, but the overall form strongly suggests it is a product box. There are no features that would identify it as a specific type of product (e.g., a phone, a book, etc.), so the most accurate classification is based on its general form."
+    },
+    {
+      "asset_name": "gso_Phillips_Caplets_Size_24",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8797,
+      "qwen_classification": "medication box",
+      "qwen_reasoning": "The image shows a white and blue box with the brand name \"Phillips\" and the word \"Caplets\" visible. This is clearly a pharmaceutical product packaging, specifically for caplet tablets. The design and labeling are typical of over-the-counter or prescription medication boxes. The visible text confirms it is a container for medication, not a generic product or unrelated item."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Vitamin_C_Ester_15",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8659,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object appears to be a product packaging or informational card, likely for a skincare or cosmetic product. This is inferred from the presence of text (though illegible), percentage values (76%, 80%, 83%), and diagrams that resemble facial contours or application areas. The orange circular graphic and the overall layout suggest it's designed to convey product efficacy or usage instructions. The object is flat and rectangular, consistent with packaging material."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_The_Metabolic_Formula_Supplements",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8677,
+      "qwen_classification": "supplement container",
+      "qwen_reasoning": "The object is a rectangular box with visible text that reads 'Supplement Facts' on its side. This text is characteristic of nutritional supplement packaging. The box has a clean, commercial design with a white background and some colored accents (red, yellow, black) visible on the side. The shape and labeling strongly suggest it is a product container for dietary supplements, such as vitamins or protein powder. The perspective shows the side and top of the box, confirming it is a packaged product."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_The_Crease_Cure_Duo",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8501,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a black, rectangular box with text printed on its top surface. The text appears to be in multiple lines, likely product information or branding. The box has a solid, rigid appearance with sharp edges, typical of packaging for electronic devices, software, or consumer products. The perspective shows it at an angle, revealing its three-dimensional form. Given the lack of visible logos or specific product identifiers, it is difficult to determine the exact product, but its shape and printed text strongly suggest it is a product box."
+    },
+    {
+      "asset_name": "gso_Philips_Sonicare_Tooth_Brush_2_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8374,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed branding and imagery. The visible text includes \"Scented\" and \"Scented\" (likely a brand name), along with images of what appear to be scented candles or similar products. The design suggests it is packaging for consumer goods, specifically scented items. The angled view and cropped nature indicate it's a product box, not a container or other type of packaging."
+    },
+    {
+      "asset_name": "gso_Philips_EcoVantage_43_W_Light_Bulbs_Natural_Light_2_pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 9194,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a cardboard box with visible features such as a barcode on one side, printed text and graphics on the top and sides, and a partially open flap. These are typical characteristics of a shipping or product packaging box. The box appears to be for a consumer product, given the presence of branding and labeling. The perspective shows it from an angled view, revealing multiple sides, which is consistent with a standard rectangular cardboard box."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Omega_3_Supplements",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8464,
+      "qwen_classification": "cosmetic product box",
+      "qwen_reasoning": "The object is a rectangular, box-like item with a light beige or cream color. It appears to be a product package, likely for a cosmetic or skincare item, given the minimalist design and the presence of a stylized fish illustration on the front. The text on the side is partially visible and seems to be in a foreign language (possibly Japanese or Korean), which is common for beauty products in those regions. The overall shape and presentation suggest it is a retail box for a single item, such as a serum, cream, or mask. The fish illustration may indicate the product contains fish-derived ingredients or is themed around marine elements."
+    },
+    {
+      "asset_name": "gso_Persona_Q_Shadow_of_the_Labyrinth_Nintendo_3DS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8588,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The image displays a video game case for the Nintendo 3DS console. The cover art features the title \"Persona Q\" prominently, along with multiple colorful character illustrations. The Nintendo 3DS logo is visible on the spine of the case, confirming the platform. The case also includes text indicating it is a \"FREE TRIAL + DLC SET INCLUDED\" and has an \"M\" (Mature) rating. This is clearly a physical game cartridge case for a specific video game."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_The_Cold_Plasma_Face_Eyes_Duo",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8668,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a black rectangular box with a printed image on its top surface. The image appears to be a technical or schematic illustration, possibly of a mechanical or electronic component, with lines and shapes suggesting wiring or internal structure. There is also a red circular logo or label in the upper left corner. The overall appearance is consistent with packaging for a product, likely an electronic component, hardware, or specialized equipment. The text on the side is too small and indistinct to read, but the design suggests it is a product box."
+    },
+    {
+      "asset_name": "gso_Phillips_Stool_Softener_Liquid_Gels_30_liquid_gels",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8850,
+      "qwen_classification": "medication box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and text visible. The prominent brand name \"Philips\" is displayed in large letters, along with the product name \"Sensory Care\" and an image of two pink pills. This indicates it is a consumer product package, likely for a health or wellness item such as vitamins, supplements, or medication. The design and labeling are typical of pharmaceutical or health supplement packaging."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Photo_Plasma",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8862,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The image shows a product box with text that reads \"Photo Pluma\" and \"Pentax Photo Pluma\". The box also indicates a volume of \"6.39 mL / 0.21 oz\". The design features a dark blue and purple gradient with an image of a small bottle or container. This is clearly packaging for a photographic product, likely a liquid such as a cleaning solution, developer, or other photographic chemical. The branding and volume suggest it is a specialized product for photography, specifically for Pentax equipment. The object is a product box, not the product itself, but the context and text make its contents identifiable."
+    },
+    {
+      "asset_name": "gso_Pinwheel_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8336,
+      "qwen_classification": "play tunnel",
+      "qwen_reasoning": "The object is a cylindrical, fabric tunnel with a colorful, geometric pattern. It appears to be designed for play, likely for children, given its bright colors and shape. The structure suggests it is collapsible or portable, commonly used in play areas or gyms as an obstacle course or hide-and-seek item. The visible end shows a circular opening, consistent with a tunnel design."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Vitamin_C_Ester_Serum",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8694,
+      "qwen_classification": "skincare serum",
+      "qwen_reasoning": "The image shows a product package for a skincare item. The text on the packaging clearly reads \"Vitamin C Ester Serum\" and includes volume information (\"30 mL / 1 fl oz\"). The visual design features an illustration of a dropper bottle, which is typical for serums. The brand name \"PETERSON MED\" is also visible. This is a cosmetic product, specifically a serum used for skin care, likely for brightening or antioxidant purposes due to the Vitamin C content."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Skin_Total_Body_Supplements",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8900,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a rectangular cardboard box, likely for packaging or shipping. It has printed text and graphics on its visible surfaces, which is typical for product packaging. The box appears to be made of corrugated cardboard, as suggested by its texture and the way it's folded. The perspective shows multiple sides of the box, indicating it's a standard rectangular prism shape. The printed content includes what looks like barcodes, text blocks, and possibly diagrams or charts, which are common on product boxes for labeling and instructions. The object is clearly a container, not a consumable item or electronic device."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_The_Power_Treatments",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8712,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a white, rectangular box with printed text on its surface. The text appears to be organized into multiple columns or sections, suggesting it is packaging for a product. The clean, minimalist design and the presence of text indicate it is likely a product box, possibly for electronics, software, or another consumer item. The perspective is angled, showing the top and one side of the box. There are no visible logos or brand names that are clearly identifiable from this view, but the overall shape and printed content are consistent with commercial packaging."
+    },
+    {
+      "asset_name": "gso_Phillips_Colon_Health_Probiotic_Capsule",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8824,
+      "qwen_classification": "supplement box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and text visible. The text \"Colon Health\" and \"Philips\" is clearly legible, along with the word \"Fiber\" and a green banner. The design includes pink and purple colors with a stylized image of a colon. This packaging is characteristic of a health supplement or dietary product, specifically one related to digestive health. The box shape, labeling, and branding are consistent with commercial product packaging for vitamins or fiber supplements."
+    },
+    {
+      "asset_name": "gso_Pokmon_Conquest_Nintendo_DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8307,
+      "qwen_classification": "video game cartridge",
+      "qwen_reasoning": "The object is a video game cartridge for the Nintendo DS console. This is identifiable by the distinct shape of the cartridge, the visible 'NINTENDO DS' logo on the top right corner, and the colorful artwork on the front cover which is typical for game packaging. The object is angled, showing its front and top edges, but the key identifying features are clearly visible."
+    },
+    {
+      "asset_name": "gso_Pokmon_X_Nintendo_3DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8586,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The object is a video game case, specifically for the Nintendo Wii console. This is evident from the visible artwork featuring characters from the Super Smash Bros. series, the Nintendo Wii logo, and the typical layout of a game case back cover which includes screenshots, game description, and rating information. The case is angled, showing its back side with text and images, which is standard for video game packaging."
+    },
+    {
+      "asset_name": "gso_Poppin_File_Sorter_Pink",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8787,
+      "qwen_classification": "foldable table",
+      "qwen_reasoning": "The object shown is a portable, foldable table with a rectangular top and a metal frame. The frame consists of curved legs that are designed to fold under the tabletop, which is a common design for camping or travel tables. The bright pink color is likely for aesthetic or branding purposes. The structure is lightweight and compact, indicating it is intended for temporary or mobile use."
+    },
+    {
+      "asset_name": "gso_PureCadence_2_Color_HiRskRedNghtlfeSlvrBlckWht_Size_70",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8256,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, specifically a running shoe, characterized by its bright red upper, white sole, and distinctive white logo on the side. The design, including the lacing system and overall silhouette, is typical of modern running footwear. The white background indicates it has been segmented from its original context, but the object's features are clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Prostate_Optimizer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8160,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a dark blue bottle with a black cap. The label clearly displays the text \"Prostate Optimizer\" in white and gold lettering, along with a logo that appears to be \"NUTRA\". This indicates it is a dietary supplement bottle, specifically marketed for prostate health. The shape, labeling, and context are consistent with a typical supplement container."
+    },
+    {
+      "asset_name": "gso_Polar_Herring_Fillets_Smoked_Peppered_705_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8277,
+      "qwen_classification": "canned food",
+      "qwen_reasoning": "The object is a can with a pull-tab lid, typical of canned food or beverages. The label features the brand name \"Polair\" and an image of what appears to be a cooked fish or seafood dish. The shape, pull-tab, and labeling are characteristic of a canned food product, likely a canned fish such as tuna or sardines, commonly found in grocery stores. The visual evidence strongly supports this classification."
+    },
+    {
+      "asset_name": "gso_PhosphOmega",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8603,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that includes text, a barcode, and nutritional information. The shape, cap, and labeling are characteristic of a supplement or medication bottle. The label has a blue and red border, and the text appears to be in a language other than English (possibly Spanish or Portuguese), which is common for products sold in certain regions. The bottle is tilted, showing the side and bottom, which is typical for product photography or packaging shots. Based on these features, it is clearly a container for pills or capsules."
+    },
+    {
+      "asset_name": "gso_Provence_Bath_Towel_Royal_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8412,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a folded, textured fabric item with a deep blue color. The visible texture and the way it is folded suggest it is a soft, absorbent material, consistent with a towel. The folds and creases indicate it is pliable and likely made of a terry cloth or similar material commonly used for towels. There are no other features to suggest it is anything other than a towel."
+    },
+    {
+      "asset_name": "gso_Philips_60ct_Warm_White_LED_Smooth_Mini_String_Lights",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8232,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object is a rectangular box with the brand name \"PHILIPS\" prominently displayed in blue lettering. The box has a blue and white color scheme, and there is a small circular logo or image near the top. The presence of the Philips brand, combined with the box's shape and labeling, strongly suggests it is packaging for a consumer electronic product, such as a light bulb, a small appliance, or a medical device. The recycling symbol on the side further supports that it is product packaging. Given the visible branding and typical product packaging design, it is most likely a box for a Philips product."
+    },
+    {
+      "asset_name": "gso_REEF_BANTU",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8191,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a brown, leather-like boot with visible lacing and a thick sole. The design suggests it is a type of work boot or casual boot, characterized by its sturdy construction and laced closure. The angle of the image shows the side and top portion of the boot, highlighting its form and features."
+    },
+    {
+      "asset_name": "gso_REEF_BRAIDED_CUSHION",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 7851,
+      "qwen_classification": "flip-flop",
+      "qwen_reasoning": "The object is a black flip-flop sandal with a distinct pink strap. The shape, including the sole and the thong-style strap, is characteristic of a flip-flop. The pink strap is a common decorative feature on this type of footwear. The object is clearly identifiable as a type of casual footwear."
+    },
+    {
+      "asset_name": "gso_Pokmon_Y_Nintendo_3DS_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8582,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The object is a video game case for the Nintendo 3DS console. The artwork on the cover features a prominent Pok\u00e9mon character, specifically the legendary Pok\u00e9mon 'Mega Charizard X', which is identifiable by its red and blue coloration and dragon-like form. The 'Pok\u00e9mon' logo is clearly visible in its distinctive yellow font, and the 'Nintendo 3DS' branding is present at the bottom right. The overall design and layout are characteristic of official Nintendo 3DS game packaging."
+    },
+    {
+      "asset_name": "gso_Quercetin_500",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8520,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a purple label and a barcode visible on the side. The shape, cap, and labeling are characteristic of a supplement or medication bottle commonly found in pharmacies or health food stores. The label appears to contain nutritional information or product details, which is typical for such containers. The object is clearly identifiable as a pharmaceutical or dietary supplement container."
+    },
+    {
+      "asset_name": "gso_PureFlow_2_Color_RylPurHibiscusBlkSlvrWht_Size_50",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8218,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has features typical of a running or training shoe, including a lace-up closure, a structured upper, and a visible sole with a tread pattern. The color scheme is predominantly purple with red accents on the laces and some details. The overall design and construction suggest it is intended for athletic use, likely running or cross-training."
+    },
+    {
+      "asset_name": "gso_Predito_LZ_TRX_FG_W",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8182,
+      "qwen_classification": "soccer cleat",
+      "qwen_reasoning": "The object is a close-up view of a sports shoe, specifically a soccer cleat. Key identifying features include the three parallel stripes on the side (a signature design of Adidas), the molded studs on the sole for traction, and the overall shape typical of soccer footwear. The color scheme is white with blue stripes and pink accents on the toe area. The object is clearly segmented from its background, and the visible parts are consistent with a soccer cleat."
+    },
+    {
+      "asset_name": "gso_QAbsorb_CoQ10_53iUqjWjW3O",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8455,
+      "qwen_classification": "pill bottle",
+      "qwen_reasoning": "The object is a white cylindrical container with a label wrapped around its body. The label contains text and a barcode, which is typical for product packaging. The shape and labeling suggest it is a container for pills, supplements, or another type of medication or health product. The yellow accent on the label adds to its commercial packaging appearance. Given the context and visual cues, this is most likely a pill bottle or supplement container."
+    },
+    {
+      "asset_name": "gso_Razer_Abyssus_Ambidextrous_Gaming_Mouse",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8326,
+      "qwen_classification": "computer mouse",
+      "qwen_reasoning": "The object is a black computer mouse with a visible USB cable attached. It has a standard ergonomic shape with a scroll wheel and buttons, typical of a computer mouse. The brand logo (Razer) is visible on the bottom, confirming it is a gaming or performance mouse. The object is clearly identifiable as a computer peripheral device."
+    },
+    {
+      "asset_name": "gso_Ravenna_4_Color_WhtOlyBluBlkShkOrngSlvRdO_Size_70",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8015,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It features a mesh upper, laces, a padded collar, and a rubber sole, all characteristic of running or training footwear. The color scheme includes blue, orange, and black. The design and construction are consistent with modern running shoes, which are engineered for performance and comfort during running activities."
+    },
+    {
+      "asset_name": "gso_Poppin_File_Sorter_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8684,
+      "qwen_classification": "spring",
+      "qwen_reasoning": "The object shown is a stylized, abstract representation of a spring or coil. It consists of multiple curved, parallel lines that form a helical shape, suggesting a coiled spring. The object is depicted in a 3D perspective with shading, giving it depth and dimension. The blue color and the way the lines are arranged are characteristic of a mechanical spring, commonly used in devices like pens, mattresses, or suspension systems. The object is not a real-world spring in a functional context but rather a graphic or schematic representation."
+    },
+    {
+      "asset_name": "gso_RJ_Rabbit_Easter_Basket_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8719,
+      "qwen_classification": "basket",
+      "qwen_reasoning": "The object appears to be a small, woven basket or container with a blue handle. It has a white, textured body with blue trim and a decorative blue and green floral pattern on the front. The shape is rectangular with rounded corners, and it seems to be designed for carrying or holding small items. The construction suggests it is made of woven material, possibly plastic or synthetic fibers, common in decorative or utility baskets."
+    },
+    {
+      "asset_name": "gso_PureConnect_2_Color_FernNightlifeSilverBlack_Size_70_5w0BYsiogeV",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8227,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has a distinct shape with a curved, elongated form and a pattern of black circular indentations on one side. The color scheme is bright green and yellow, which is common for athletic footwear. The overall structure, including the visible sole and upper part, strongly suggests it is a shoe, likely a sneaker or athletic shoe, viewed from an angled perspective. The black circular indentations appear to be part of the sole design, possibly for traction or aesthetic purposes."
+    },
+    {
+      "asset_name": "gso_PureConnect_2_Color_AnthrcteKnckoutPnkGrnGecko_Size_50",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 7929,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a bright green, textured item with multiple pink circular patterns on its surface. The shape and texture suggest it is a type of footwear, specifically a shoe. The pink circles appear to be decorative or functional elements, possibly representing grip patterns or design features. The overall form, including the curved shape and the visible sole-like structure, is consistent with a shoe, likely a casual or athletic style. The object is viewed from an angled perspective, showing part of the side and sole."
+    },
+    {
+      "asset_name": "gso_PureCadence_2_Color_TleBluLmePnchSlvMoodIndgWh_Size_50_EEzAfcBfHHO",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 7997,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a partial view of a sneaker, identifiable by its distinct shoe structure including the upper material, lacing system, midsole, and outsole tread pattern. The color scheme features white, light blue, and neon yellow accents, which are common in athletic footwear. The visible design elements, such as the curved sole and the patterned rubber tread, are characteristic of running or training shoes. The cropped view focuses on the side and heel area, but the overall form is unmistakably that of a shoe."
+    },
+    {
+      "asset_name": "gso_Pokmon_Omega_Ruby_Alpha_Sapphire_Dual_Pack_Nintendo_3DS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8503,
+      "qwen_classification": "video game cartridge",
+      "qwen_reasoning": "The object is a video game cartridge for the Nintendo 3DS console. This is identifiable by the 'Nintendo 3DS' logo clearly visible on the lower left corner of the cartridge. The artwork on the front cover features characters and branding consistent with the Pok\u00e9mon franchise, specifically 'Pok\u00e9mon X' and 'Pok\u00e9mon Y', which are known titles for the Nintendo 3DS. The physical form factor, including the rectangular shape with rounded edges and the distinct top and bottom sections, is characteristic of Nintendo 3DS game cartridges. The object is presented at an angle, showing its front and top surfaces."
+    },
+    {
+      "asset_name": "gso_Razer_Taipan_White_Ambidextrous_Gaming_Mouse",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8380,
+      "qwen_classification": "computer mouse",
+      "qwen_reasoning": "The object shown is a computer mouse. It has a typical ergonomic shape with a left and right button configuration, a scroll wheel (visible as a darker band in the center), and a coiled cable extending from its rear. The color is primarily white with black accents. This is a standard input device used with computers."
+    },
+    {
+      "asset_name": "gso_QAbsorb_CoQ10",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8543,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object appears to be a cylindrical container with a label wrapped around it. The label has text, a barcode, and what looks like nutritional or supplement information, which is typical for a dietary supplement bottle. The shape and labeling suggest it is a container for pills or capsules. The red stripe and partial text (e.g., \"D3\") further support this being a vitamin or supplement bottle. The object is not a water bottle, food container, or any other type of container based on its shape and labeling."
+    },
+    {
+      "asset_name": "gso_Predator_LZ_TRX_FG",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8131,
+      "qwen_classification": "sports shoe",
+      "qwen_reasoning": "The object shown is a cropped, angled view of a sports shoe, specifically focusing on the upper portion near the heel and midfoot. Key visual features include the distinctive three parallel stripes on the side, which are a hallmark of Adidas branding. The shoe has a white base color with red accents along the heel and side, and appears to have a textured or patterned sole area visible at the bottom. The shape and design are consistent with modern athletic footwear, likely designed for soccer or general sports use. The cropped nature and white background suggest this is a product image highlighting specific design elements."
+    },
+    {
+      "asset_name": "gso_PureConnect_2_Color_BlckBrllntBluNghtlfeAnthrct_Size_70",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8149,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. It has a dark, likely black, upper with some green and blue accents. The shape is consistent with a modern athletic shoe, featuring a curved toe box and a defined heel. The green stripes near the midfoot and the blue trim along the edge suggest a design typical of sports or casual footwear. The object is viewed from a side angle, showing the profile of the shoe. The segmentation and cropping focus solely on the shoe, with no other context provided."
+    },
+    {
+      "asset_name": "gso_QHPomegranate",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8708,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that has red and gray sections. The shape is cylindrical with a slightly tapered neck, typical of supplement or medication bottles. The label appears to have text and possibly a logo, but the details are not legible in the image. Given the context and appearance, it is most likely a container for pills, vitamins, or another type of oral supplement. The object is clearly identifiable as a bottle, and its specific use can be reasonably inferred as a supplement container based on common packaging designs."
+    },
+    {
+      "asset_name": "gso_Razer_BlackWidow_Ultimate_2014_Mechanical_Gaming_Keyboard",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8259,
+      "qwen_classification": "horse",
+      "qwen_reasoning": "The object appears to be a stylized, abstract representation of a horse's head and neck. The silhouette shows a distinct shape with a pointed ear, a snout, and a neck that curves upward. The overall form is consistent with the profile of a horse, even though it is simplified and lacks detailed features. The black color and clean lines suggest it might be a logo, icon, or graphic design element rather than a photograph of a real horse."
+    },
+    {
+      "asset_name": "gso_REEF_ZENFUN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 7882,
+      "qwen_classification": "shoe insole",
+      "qwen_reasoning": "The object shown is a gray, textured, curved piece with a distinct shape that resembles the insole or sole of a shoe. The surface has a patterned texture, likely for grip or comfort, and the overall form is consistent with the bottom part of a shoe. The curved, elongated shape with a raised edge on one side is typical of shoe soles designed to fit the foot's contour. The object is not a complete shoe, but rather a component of one, specifically the insole or sole."
+    },
+    {
+      "asset_name": "gso_Razer_Kraken_Pro_headset_Full_size_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8419,
+      "qwen_classification": "headphones",
+      "qwen_reasoning": "The object is a pair of over-ear headphones. Key features include the large circular earcups designed to cover the ears, a padded headband for comfort, and a visible brand logo ('RAZER') on the side of the headband. The design and branding are characteristic of gaming or audio-focused headphones. The green accent lighting along the headband is also a common feature in Razer products, further supporting this identification."
+    },
+    {
+      "asset_name": "gso_Real_Deal_1nIwCHX1MTh",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8287,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It features a bright blue upper with neon yellow accents along the sole, heel, and lacing area. The design includes visible laces, a padded collar, and a structured sole, all characteristic of athletic footwear. The shape and construction suggest it is designed for sports or active use, likely a running or training shoe."
+    },
+    {
+      "asset_name": "gso_Rayna_BootieWP",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8469,
+      "qwen_classification": "wedge boot",
+      "qwen_reasoning": "The object shown is a dark brown, ankle-height footwear item with a thick, wedge-style sole. The material appears to be suede or a similar textured fabric. The design suggests it is a casual or fashion boot, likely a wedge boot or clog-style boot, given the elevated heel and the way the sole is integrated into the upper. The side view shows a zipper or closure mechanism near the back, which is common in such footwear for ease of wear. The overall shape and construction are consistent with a women's or unisex wedge boot."
+    },
+    {
+      "asset_name": "gso_ProSport_Harness_to_Booster_Seat",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8381,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, flat, white item with a slightly raised rim and a smooth surface. It appears to be a shallow dish or plate, likely made of ceramic or plastic, given its uniform color and matte finish. The perspective is from above and slightly angled, showing the curvature of the rim and the central depression. There is a small, brownish mark or attachment point visible near the bottom edge, which might be a mounting point or a design feature, but it does not change the fundamental classification. The object lacks any handles, patterns, or other features that would suggest it is a specific type of plate (like a salad plate or dessert plate), so the most accurate classification is a general plate or dish."
+    },
+    {
+      "asset_name": "gso_Reebok_COMFORT_REEFRESH_FLIP",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 7942,
+      "qwen_classification": "sandal",
+      "qwen_reasoning": "The object is a single sandal with a purple upper and a gray sole. It has a strap design that wraps around the foot, typical of flip-flops or slide sandals. The shape and structure suggest it is designed for casual wear or beach use. The white background indicates it has been isolated from its original context, but the object's form is clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Razer_Naga_MMO_Gaming_Mouse",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7713,
+      "qwen_classification": "power bank",
+      "qwen_reasoning": "The object is a dark, rounded, somewhat rectangular device with a cable extending from one end. Its shape and the presence of a cable suggest it is an electronic device, likely a portable charger or power bank. The form factor is consistent with common power banks, which are often compact and rectangular with rounded edges. The cable is likely for charging the device or connecting to another device. The object is not clearly identifiable as a specific brand or model, but its general shape and features strongly indicate it is a power bank."
+    },
+    {
+      "asset_name": "gso_Reebok_BREAKPOINT_LO_2V",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8231,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, specifically a slip-on style with velcro straps for closure. It has a dark blue exterior, a white sole, and a visible orange and white interior lining. The design suggests it is casual or athletic footwear, likely intended for children or for easy wear. The velcro straps indicate it is not a lace-up shoe, making it a type of velcro shoe or strap shoe."
+    },
+    {
+      "asset_name": "gso_Razer_Kraken_71_Chroma_headset_Full_size_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8699,
+      "qwen_classification": "gaming headset",
+      "qwen_reasoning": "The image shows a product box with a clear depiction of a gaming headset on the front. The branding 'Razer' is visible, along with the text 'CHROMA', which is a well-known lighting technology used by Razer for their peripherals. The headset shown has a circular earcup design with a glowing logo, consistent with Razer's aesthetic. The box also displays icons suggesting customizable lighting and multiple color options, which are features of Razer Chroma devices. This is clearly a retail packaging for a Razer gaming headset."
+    },
+    {
+      "asset_name": "gso_Reebok_ALLYLYNN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8448,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a high-top sneaker with a light blue and white color scheme, accented with yellow-green details on the tongue and laces. It has a typical sneaker structure with laces, a padded collar, and a rubber sole. The design suggests it is a casual or athletic shoe, likely for everyday wear or light sports activities. The segmented view isolates the shoe from its surroundings, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Razer_Goliathus_Control_Edition_Small_Soft_Gaming_Mouse_Mat",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8049,
+      "qwen_classification": "gaming mousepad",
+      "qwen_reasoning": "The object is a rectangular, flat item with a dark green surface and a glowing green logo or design on it. The design appears to be a stylized, abstract emblem, possibly a brand logo. The object's shape and the presence of a logo suggest it is a branded accessory, most likely a gaming mousepad. The glowing green effect is characteristic of gaming peripherals, and the design is consistent with the Razer brand, which is known for its green logo and gaming products. The object is viewed from an angled perspective, showing its top surface and one side."
+    },
+    {
+      "asset_name": "gso_Razer_Taipan_Black_Ambidextrous_Gaming_Mouse",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8325,
+      "qwen_classification": "power bank",
+      "qwen_reasoning": "The object is a black, elongated, oval-shaped item with a cord and plug attached. The shape and attached cord are characteristic of a portable electronic device. Given the silhouette, it most closely resembles a portable battery pack or a power bank, which is commonly used to charge other electronic devices. The plug suggests it connects to an electrical outlet or another device. It does not have the distinct features of a mouse, phone, or other common electronics. The object is likely a power bank due to its size, shape, and the presence of a charging cable."
+    },
+    {
+      "asset_name": "gso_ReadytoUse_Rolled_Fondant_Pure_White_24_oz_box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8836,
+      "qwen_classification": "birthday cake",
+      "qwen_reasoning": "The object appears to be a colorful, decorated cake or dessert, likely a birthday cake. It has a cylindrical shape with a purple base, topped with a large, multi-colored candy or sprinkle decoration. There is also a green square with the number '9' on it, suggesting it's for a 9th birthday. The cake is adorned with various colorful elements, including what looks like a pink bow and other decorative items. The overall appearance is festive and celebratory, consistent with a birthday cake."
+    },
+    {
+      "asset_name": "gso_Reebok_DMX_MAX_MANIA_WD_D",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8324,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a white athletic shoe, likely a sneaker, shown from a side angle. It has visible laces, a structured upper, and a thick sole with a defined heel and toe area. The design suggests it is intended for sports or casual wear, with a modern, possibly performance-oriented aesthetic. The segmented white background isolates the shoe, confirming it is the sole object of interest."
+    },
+    {
+      "asset_name": "gso_Reebok_CLASSIC_JOGGER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8209,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a white upper with blue and yellow accents along the sides and heel. The shoe features white laces, a padded collar, and a visible orange lining inside the tongue. The design and construction are typical of casual or athletic sneakers, not specialized footwear like boots or sandals. The overall appearance suggests it is a modern, lightweight sneaker suitable for everyday wear or light sports."
+    },
+    {
+      "asset_name": "gso_Reebok_CL_DIBELLO_II",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8068,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a high-top athletic shoe, characterized by its elevated ankle support, lacing system, and rubber sole. The design includes a white or light-colored upper with a darker sole, typical of sneakers. The shape and features (lacing, heel counter, sole tread) are consistent with a sports or casual sneaker, not a boot or other footwear type. The object is clearly segmented from the background, and its form is unambiguous."
+    },
+    {
+      "asset_name": "gso_Reebok_FUELTRAIN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7884,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, specifically a running or training shoe, characterized by its lightweight design, breathable mesh upper, and cushioned sole. The color is predominantly pink with white and gray accents. The lacing system, midsole, and outsole are all visible, confirming it is a shoe designed for athletic activity. The perspective is a side view, showing the shoe's profile and structure."
+    },
+    {
+      "asset_name": "gso_Reebok_DMX_MAX_PLUS_ATHLETIC",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8168,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image displays the sole of a shoe, characterized by its textured rubber bottom with a grid-like pattern for traction. There are two distinct circular indentations with blue or purple outlines, which are common design features on athletic or casual footwear for cushioning or grip. The overall shape and construction are consistent with the bottom of a shoe, specifically a sneaker or athletic shoe. The color is a light brown or tan, typical for many shoe soles."
+    },
+    {
+      "asset_name": "gso_Reebok_CL_RAYEN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8103,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a dark blue athletic shoe, likely a sneaker. Key features include the curved silhouette of the upper, a visible yellow accent stripe along the side, and the shape of the heel and sole area. The texture and stitching suggest it is made of fabric or synthetic material typical for athletic footwear. The cropped view focuses on the side and heel, which is common for showcasing shoe design. The overall shape and color scheme are consistent with modern running or training shoes."
+    },
+    {
+      "asset_name": "gso_Reebok_EASYTONE_CL_LEATHER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8414,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a white athletic shoe, likely a sneaker, based on its shape, lacing system, and overall design. It has a rounded toe, visible laces, and a padded collar. There are small purple markings on the heel and side, which may be branding or decorative elements. The construction suggests it is designed for casual wear or light athletic activity. The view is a side profile, showing the shoe's contour and structure."
+    },
+    {
+      "asset_name": "gso_Reebok_PUMP_OMNI_LITE_HLS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8347,
+      "qwen_classification": "athletic shoe",
+      "qwen_reasoning": "The object is a high-top athletic shoe with a mesh upper, synthetic overlays, and a thick rubber sole. The design suggests it is built for performance, likely for basketball or training, given the supportive structure and ankle coverage. The color scheme is dark, primarily black and grey. The visible lacing system and overall silhouette are consistent with modern athletic footwear."
+    },
+    {
+      "asset_name": "gso_Reebok_FS_HI_MINI",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8269,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a dark-colored, likely black, athletic shoe with a white sole and a small purple accent on the side. The shape, including the curved toe box, padded collar, and overall silhouette, is characteristic of a sneaker or casual athletic shoe. The stitching and paneling suggest it is designed for comfort and style, typical of modern casual or running shoes. The view is a side profile, showing the shoe's contour and sole structure."
+    },
+    {
+      "asset_name": "gso_Reebok_HIMARA_LTR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8174,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a shoe, specifically viewed from the side or heel area. It features a white upper, a prominent orange midsole with a textured pattern, and a black outsole. The design, including the cushioned sole and overall structure, is characteristic of athletic footwear, likely a running or training shoe. The segmented view isolates the shoe from its background, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Reebok_GL_6000",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8426,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a close-up view of a shoe, specifically showing the side and heel area. It has a black upper with a prominent purple accent on the heel counter. The white midsole and the visible lacing system are characteristic of athletic footwear. The brand name 'Reebok' is partially visible on the heel, confirming it is a branded athletic shoe. The design and construction suggest it is a running or training shoe."
+    },
+    {
+      "asset_name": "gso_Reebok_CL_LTHR_R12",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8134,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object has the distinct shape of a shoe, with a curved upper, a defined sole, and a visible heel area. The texture and pattern suggest it is a sports or athletic shoe, possibly a running shoe, given the streamlined design and the presence of what appears to be a logo or branding on the side. The color is a light tan or beige, and the material looks like synthetic fabric or leather commonly used in athletic footwear. The view is a side profile, showing the contour of the shoe's body and sole."
+    },
+    {
+      "asset_name": "gso_Reebok_BREAKPOINT_MID",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8280,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up of a shoe, specifically a boot or high-top style, with a distinct purple and white color scheme. The shape, including the curved toe, heel, and side profile, is consistent with footwear designed for athletic or casual wear. The white trim along the edge and the visible lacing area suggest it is a sneaker or athletic shoe. The cropped view focuses on the upper portion of the shoe, excluding the sole or laces in full detail, but the overall form is unmistakably that of a shoe."
+    },
+    {
+      "asset_name": "gso_Reebok_CLASSIC_LEGACY_II",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8446,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a dark-colored shoe, likely a sneaker or athletic shoe, based on its shape, the visible stitching, and the interior lining. The view is a close-up, cropped shot focusing on the upper portion of the shoe, showing the opening and part of the sole. The material looks like synthetic fabric or leather, and the interior has a light-colored lining. The perspective suggests it's viewed from the side or slightly above, with the toe pointing downward. The white background indicates it has been segmented from its original context."
+    },
+    {
+      "asset_name": "gso_Reebok_REALFLEX_SELECT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 7820,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object shown is a shoe, specifically a sneaker. It has a white upper with blue accents and a black sole. The design, including the lacing system and overall shape, is characteristic of athletic or casual sneakers. The view is a side profile, showing the curvature of the sole and the side of the upper. The segmented white background confirms this is a cropped view of the shoe itself."
+    },
+    {
+      "asset_name": "gso_Reebok_DMX_MAX_PLUS_RAINWALKER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8449,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a black, curved, and somewhat elongated shape with a distinct heel and toe area. The contours suggest it is a piece of footwear, specifically the sole or bottom part of a shoe. The shape is consistent with the typical form of a sneaker or athletic shoe sole, which is designed to provide cushioning and traction. The lack of visible laces, branding, or upper material makes it difficult to identify the exact type of shoe, but the overall silhouette strongly indicates it is a shoe sole."
+    },
+    {
+      "asset_name": "gso_Reebok_FS_HI_INT_R12",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8362,
+      "qwen_classification": "ice hockey skate",
+      "qwen_reasoning": "The object is a high-top athletic shoe with a distinctive design. It features a white upper with red accents along the sole and side panels, and black at the toe and heel. The shoe has visible lacing and a padded collar, typical of performance footwear. The overall shape and construction suggest it is designed for sports or athletic activities, possibly for ice hockey or similar high-impact sports, given the reinforced structure and style. The red and white color scheme with graphic elements on the side is also characteristic of branded athletic footwear."
+    },
+    {
+      "asset_name": "gso_Reebok_SH_COURT_MID_II",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8512,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a high-top sneaker, identifiable by its elevated ankle support, velcro strap closure system, and distinct color blocking (dark gray/black upper with white stripe and blue accents). The visible sole and overall construction suggest it is a casual or athletic shoe designed for everyday wear. The cropped view focuses on the side and heel area, showing the typical design elements of a modern sneaker."
+    },
+    {
+      "asset_name": "gso_Reebok_SH_PRIME_COURT_LOW",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8129,
+      "qwen_classification": "shoe insole",
+      "qwen_reasoning": "The object shown is a shoe insole, also known as a footbed. It has a contoured shape designed to fit the foot, with a textured surface for grip and comfort. The visible blue layer underneath suggests it may be a cushioned or supportive insole, often used in athletic or orthopedic footwear. The overall structure and design are consistent with insoles used to provide arch support and comfort inside shoes."
+    },
+    {
+      "asset_name": "gso_Reebok_KAMIKAZE_II_MID",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8192,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a single shoe, likely a sneaker or athletic shoe, based on its shape, the visible sole structure, and the patterned design on the upper. The black and white abstract pattern is common on casual or athletic footwear. The perspective is a side or angled view, showing the side profile and part of the toe and heel. The object is clearly segmented from the background, and no other objects are visible. The shape is consistent with a human shoe, not an animal paw or other object."
+    },
+    {
+      "asset_name": "gso_Reebok_SMOOTHFLEX_CUSHRUN_20",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8198,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It features a mesh upper with a patterned design, a visible lacing system, and a thick, cushioned sole with a wavy tread pattern. The color scheme is primarily gray with teal or light blue accents on the laces, heel, and sole. These features are characteristic of modern running or training shoes designed for comfort and performance."
+    },
+    {
+      "asset_name": "gso_Reebok_RETRO_RUSH_2V",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 7992,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a close-up of the sole of a shoe. The visible features include the brand name 'Reebok' printed in yellow on a dark blue rubber sole. The sole has a textured pattern typical of athletic footwear, and a yellow accent is visible at the heel. This is clearly a part of a shoe, specifically the outsole or midsole area, which is commonly seen in sneakers or athletic shoes. The branding and design are characteristic of Reebok's athletic shoe line."
+    },
+    {
+      "asset_name": "gso_Reebok_ULTIMATIC_2V",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8198,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a white upper with pink accents and a prominent pink sole. The design, including the lacing system and overall shape, is characteristic of a running or training shoe. The pink and white color scheme is common in athletic footwear, particularly for women's or unisex models. The segmented white background confirms this is a cropped view of the shoe itself."
+    },
+    {
+      "asset_name": "gso_Reebok_REESCULPT_TRAINER_II",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8282,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a white shoe with a visible sole and heel. The shape, including the curved toe box and the tread pattern on the sole, is characteristic of athletic footwear. The presence of a logo or design on the side (a faint green mark) further supports that this is a branded shoe, likely for sports or casual wear. The view is angled, showing the side and bottom of the shoe, which is typical for product photography. Based on these features, it is confidently identifiable as a shoe, specifically an athletic or running shoe."
+    },
+    {
+      "asset_name": "gso_Remington_TStudio_Silk_Ceramic_Hair_Straightener_2_Inch_Floating_Plates",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8156,
+      "qwen_classification": "hair straightener",
+      "qwen_reasoning": "The object shown is a hair straightener, also known as a flat iron. It has two parallel heated plates for styling hair, a handle for grip, and a power cord with a plug. The design is typical of modern hair styling tools, with a black and red color scheme. The segmented view isolates the device from its surroundings, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Reebok_SL_FLIP_UPDATE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8255,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The image shows a close-up of a white athletic shoe, specifically focusing on the heel and ankle collar area. A prominent gold-colored logo, which appears to be the letter 'R', is visible on the side of the heel. The shoe has a high-top design, indicated by the elevated collar, and features gold-colored eyelets for laces. These details are characteristic of a sneaker or athletic shoe, likely a brand-specific model given the logo. The object is clearly identifiable as footwear."
+    },
+    {
+      "asset_name": "gso_Reebok_JR_ZIG_COOPERSTOWN_MR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8401,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole and heel area of a shoe. Key features include a black rubber outsole with red accents along the edges, a white or silver stripe design on the side, and the visible heel counter. The shape and construction are consistent with athletic footwear, specifically designed for performance or training. The red and black color scheme is common in sports shoes. The view is from the side and slightly angled, focusing on the structural elements of the shoe's bottom and heel. Based on these visual cues, it is clearly a shoe, likely an athletic or training shoe."
+    },
+    {
+      "asset_name": "gso_Reebok_R_CROSSFIT_OLY_UFORM",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8325,
+      "qwen_classification": "sports shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole of a shoe. Key features include a black rubber outsole with a pattern of rectangular studs or lugs, which are designed for traction. The upper part of the shoe appears to be white or light gray with some dark markings, possibly stripes or branding. This type of sole design is common in athletic footwear, particularly for sports like soccer, football, or general training, where grip and stability are important. The shape and construction suggest it is a sports shoe rather than a casual or formal shoe."
+    },
+    {
+      "asset_name": "gso_Reebok_ZIGTECH_SHARK_MAYHEM360",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8363,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a light-colored athletic shoe, viewed from a top-down angle. Key features include visible laces, a padded collar, a structured upper, and a thick sole with a textured pattern. The overall design is consistent with modern running or training shoes, characterized by its streamlined silhouette and cushioned appearance. The white background and cropping suggest it is a product image, but the object itself is clearly identifiable as a shoe."
+    },
+    {
+      "asset_name": "gso_Reebok_ZIGLITE_RUSH_AC",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8199,
+      "qwen_classification": "athletic shoe",
+      "qwen_reasoning": "The object shown is a close-up view of a shoe, specifically focusing on the side and heel area. It features a purple and pink color scheme with white laces and a white sole. The design, including the lacing system and overall shape, is consistent with athletic footwear, likely designed for sports such as basketball or general athletic use. The visible branding or logo on the side further supports that this is a manufactured athletic shoe."
+    },
+    {
+      "asset_name": "gso_Reebok_TURBO_RC",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8313,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up view of a shoe, specifically focusing on the side and lacing area. It features a dark gray or black upper with bright yellow laces and a yellow logo or design element on the side. The shape, lacing system, and overall construction are consistent with athletic footwear, likely designed for sports or exercise. The cropped view isolates the shoe from its surroundings, but the key features are clearly identifiable as those of a shoe."
+    },
+    {
+      "asset_name": "gso_Room_Essentials_Bowl_Turquiose",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8573,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, shallow dish with a smooth, glossy surface and a slightly raised rim. The bottom has a central white label with text and markings, which is typical for manufactured ceramic or porcelain dinnerware. The color is a muted greenish-blue, and the shape suggests it is designed for holding food. The object appears to be a plate or a shallow bowl, likely for dining purposes."
+    },
+    {
+      "asset_name": "gso_Reebok_STUDIO_BEAT_LOW_V",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8313,
+      "qwen_classification": "bucket hat",
+      "qwen_reasoning": "The object is a dark-colored, likely black, head covering with a distinct shape. It has a rounded crown and a wide, downward-sloping brim, characteristic of a bucket hat. There is a stylized, glowing teal or cyan graphic on the side, which appears to be a logo or design element. The material looks soft and flexible, consistent with fabric used for casual headwear. The overall form and features strongly suggest it is a bucket hat, often worn for fashion or sun protection."
+    },
+    {
+      "asset_name": "gso_Reebok_R_DANCE_FLASH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8112,
+      "qwen_classification": "shoe sole",
+      "qwen_reasoning": "The object shown is a close-up of the sole of a shoe. It has a distinct tread pattern with grooves and ridges designed for traction. The color scheme is primarily dark blue with bright blue accents, particularly around the heel and toe areas. The shape is curved and elongated, consistent with the bottom of a human shoe. The design suggests it could be for athletic or casual wear, but the specific type (e.g., running, hiking, etc.) cannot be determined from this view alone. However, it is clearly identifiable as a shoe sole."
+    },
+    {
+      "asset_name": "gso_Reebok_ZIGCOOPERSTOWN_QUAG",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8132,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a black athletic shoe with a white stripe along the side. The visible portion shows the upper part of the shoe, including the toe box and side panel. The brand logo 'Reebok' is visible on the side, indicating it is a Reebok brand shoe. The design, including the shape and the white stripe, is characteristic of a running or training shoe. The object is clearly segmented from the background, and the focus is on the shoe itself."
+    },
+    {
+      "asset_name": "gso_Retail_Leadership_Summit_tQFCizMt6g0",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8422,
+      "qwen_classification": "hat",
+      "qwen_reasoning": "The object is a dark-colored, structured hat with a rounded crown and a flat brim. It features a light-colored band around the base of the crown, which appears to have a small button or decorative element on it. The texture suggests it is made of woven material, possibly straw or a similar fabric. This style is characteristic of a boater hat or a similar type of summer hat, often worn for casual or formal occasions."
+    },
+    {
+      "asset_name": "gso_Reebok_VERSA_TRAIN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8335,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is the sole of a shoe, characterized by its distinct tread pattern with multiple grooves and ridges designed for traction. The visible structure includes a black rubber outsole with a white midsole or heel section, which is typical of athletic footwear. The shape and design are consistent with a running shoe or similar performance shoe, given the emphasis on grip and cushioning. The cropped view focuses only on the bottom portion, but the features are sufficient to confidently classify it as a shoe sole."
+    },
+    {
+      "asset_name": "gso_Reebok_SH_PRIME_COURT_MID",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8197,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a single shoe, viewed from a top-down perspective. It has a light pink upper, white laces, and a white sole. The shape, lacing system, and overall design are characteristic of a casual sneaker or athletic shoe. The interior lining appears to be dark, possibly black or dark red, which is visible at the opening. There are no specific indicators (like cleats, spikes, or racing stripes) to classify it as a specialized type like a soccer or running shoe, so the most accurate general classification is 'sneaker'."
+    },
+    {
+      "asset_name": "gso_Reef_Star_Cushion_Flipflops_Size_8_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7996,
+      "qwen_classification": "flip-flop",
+      "qwen_reasoning": "The object shown is a single black flip-flop. It has a flat sole and a thong strap that goes between the big toe and second toe, which is characteristic of flip-flops. The material appears to be a soft, flexible synthetic material, common for casual footwear. The object is presented in a side view, showing its profile and the strap structure. There are no other distinguishing features that would suggest a specific brand or type beyond being a standard flip-flop."
+    },
+    {
+      "asset_name": "gso_Retail_Leadership_Summit",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8729,
+      "qwen_classification": "hat",
+      "qwen_reasoning": "The object is a hat with a distinct shape featuring a rounded crown and a brim. It has a brown color with a lighter band around the base of the crown. This style is characteristic of a fedora or trilby hat, commonly worn as formal or casual headwear. The texture and shading suggest it is made of felt or a similar material, and the band is likely decorative. The view is a cropped, angled perspective focusing on the top and side of the hat."
+    },
+    {
+      "asset_name": "gso_Room_Essentials_Salad_Plate_Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8197,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is a circular, shallow dish with a smooth, light blue surface. It has a raised rim and a slightly concave center, which is characteristic of a plate used for serving food. The uniform color and lack of any patterns or markings suggest it is a simple, functional plate. The perspective is top-down, showing the circular shape and the curvature of the rim."
+    },
+    {
+      "asset_name": "gso_Room_Essentials_Dish_Drainer_Collapsible_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8494,
+      "qwen_classification": "takeout container",
+      "qwen_reasoning": "The object is a rectangular, light-colored plastic container with rounded corners and a slightly raised rim. The surface appears smooth and uniform, with no visible markings or text. The shape and material suggest it is a food or beverage container, likely designed for single-use or takeout purposes. The slight shadowing and perspective indicate it is a physical object photographed from an angled top-down view. This is consistent with common disposable food containers or takeout trays."
+    },
+    {
+      "asset_name": "gso_Remington_1_12_inch_Hair_Straightener",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7503,
+      "qwen_classification": "knife",
+      "qwen_reasoning": "The object has a long, slender, tapered shape with a pointed tip, resembling a tool designed for precision work. The handle is ergonomically shaped with a red and black color scheme and includes a lanyard or strap for secure handling. This design is characteristic of a tactical or utility knife, often used for cutting, prying, or other tasks requiring a sharp, pointed implement. The overall form and features strongly suggest it is a knife, specifically one designed for utility or tactical purposes."
+    },
+    {
+      "asset_name": "gso_Reebok_SOMERSET_RUN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7998,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up view of the sole of a shoe. Key features include the curved shape of the heel and forefoot, the textured rubber outsole with visible tread patterns (specifically, vertical grooves or channels), and the overall structure consistent with footwear designed for walking or running. The color is a dark brown or black, typical of athletic or casual shoes. The perspective is from the bottom, looking up at the sole, which is a common way to display shoe soles for product or design purposes. There are no other objects or context to suggest it is anything other than a shoe sole."
+    },
+    {
+      "asset_name": "gso_SCHOOL_BUS",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8096,
+      "qwen_classification": "toy school bus",
+      "qwen_reasoning": "The object is a small, yellow, rectangular toy vehicle with wheels, resembling a school bus. It has a simplified design with windows along the side, a front windshield, and a red light on top. The shape, color, and features are characteristic of a toy school bus, commonly found in children's playsets or educational toys."
+    },
+    {
+      "asset_name": "gso_Rose_Garden_Tieks_Leather_Ballet_Flats_with_Floral_Rosettes",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 7900,
+      "qwen_classification": "massage tool",
+      "qwen_reasoning": "The object appears to be a small, curved, ergonomic device with a teal-colored surface and a patterned top. The shape and design suggest it is a handheld massager or a similar personal care device, possibly for neck or shoulder relief. The visible branding or text on the side further supports that it is a manufactured consumer product. The overall form factor is consistent with a handheld massage tool or a similar wellness device."
+    },
+    {
+      "asset_name": "gso_Retail_Leadership_Summit_eCT3zqHYIkX",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8237,
+      "qwen_classification": "mortar",
+      "qwen_reasoning": "The object appears to be a dark, circular, bowl-shaped item with a textured surface. The interior is hollow and has a slightly concave bottom. The shape and texture are consistent with a traditional mortar, which is used for grinding substances. The object is viewed from above, showing its open top and the inner grinding surface. The material appears to be stone or ceramic, which is typical for mortars. There is a small label or marking visible on the inner rim, which is common on manufactured mortars for identification or branding."
+    },
+    {
+      "asset_name": "gso_Reebok_ZIGSTORM",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8269,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has a distinct shape with a sole, upper structure, and a strap or buckle system. The bright yellow, wavy, textured sole suggests it is designed for grip or specific activity, while the light blue upper with ventilation holes and a strap indicates it is wearable footwear. The overall design resembles a type of athletic or casual shoe, possibly a slip-on or sandal-style shoe with a unique sole pattern. The segmented, stylized appearance suggests it may be a 3D model or digital rendering rather than a real-world photograph, but the form is clearly identifiable as footwear."
+    },
+    {
+      "asset_name": "gso_Reebok_ZIGLITE_RUSH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8177,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a close-up view of a shoe, specifically focusing on the upper portion including the laces, tongue, and part of the sole. The shoe has a dark, likely black, exterior with bright red laces and red accents on the tongue and inner lining. The design, with its lacing system and overall shape, is characteristic of athletic footwear. The angle suggests it's a side or angled view, but the key features are clearly identifiable as those of a shoe. Given the style and construction, it appears to be a running or training shoe, though the exact type cannot be determined without more context."
+    },
+    {
+      "asset_name": "gso_SAMOA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8463,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a shoe, specifically a high-top sneaker. This is evident from its structure: it has a thick, textured rubber sole, a visible lacing system, and a padded collar typical of high-top designs. The upper part is green with blue and white stripes, which is a common design for athletic or casual sneakers. The angle of the image shows the side and bottom of the shoe, confirming its three-dimensional form and functional design for walking or sports."
+    },
+    {
+      "asset_name": "gso_SAMe_200",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8545,
+      "qwen_classification": "product package",
+      "qwen_reasoning": "The object is a red rectangular package with a barcode and text printed on it. The barcode and text suggest it is a commercial product package, likely for a consumer item. The shape and features are consistent with a standard retail box or carton. However, without visible branding, product type, or additional context, it is not possible to confidently classify it as a specific type of product (e.g., snack, medicine, cosmetics). Therefore, the most accurate classification is a generic product package."
+    },
+    {
+      "asset_name": "gso_SHAPE_MATCHING_NxacpAY9jDt",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8481,
+      "qwen_classification": "corner guard",
+      "qwen_reasoning": "The object appears to be a white, curved plastic or rubber component with embossed geometric patterns (a hexagon and a circle). The shape and texture suggest it is a protective corner guard or bumper, commonly used on furniture, electronics, or appliances to prevent scratches or damage. The curved edge and molded design are typical for such protective covers. The shadow cast on the object further indicates it is a three-dimensional piece, likely designed to fit around a corner or edge."
+    },
+    {
+      "asset_name": "gso_Santa_Cruz_Mens",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8200,
+      "qwen_classification": "loafer",
+      "qwen_reasoning": "The object is a single slip-on shoe with a rounded toe and a low-profile sole. It appears to be made of a suede-like material in a brownish color. The design lacks laces or straps, which is characteristic of loafers or moccasins. The stitching along the edge and the overall construction suggest it is a casual, comfortable shoe intended for everyday wear."
+    },
+    {
+      "asset_name": "gso_SAMBA_HEMP",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8052,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a single shoe, specifically a brown athletic or casual sneaker. It has visible laces, a lace eyelet system, and a padded collar. The design suggests it is a low-top or mid-top sneaker, likely for everyday wear or sports. The material appears to be leather or a synthetic leather-like fabric, and the overall shape is consistent with a classic sneaker style. The object is presented in a side profile view, showing the upper, sole, and part of the heel."
+    },
+    {
+      "asset_name": "gso_Santa_Cruz_Mens_vnbiTDDt5xH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8032,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a close-up of the sole of a dark-colored shoe. The sole has a distinct tread pattern with parallel grooves, which is typical for providing traction. The shape and texture are consistent with the bottom of a casual or work shoe. The object is clearly segmented from the background, and the visible portion is characteristic of a shoe's outsole."
+    },
+    {
+      "asset_name": "gso_Romantic_Blush_Tieks_Metallic_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8065,
+      "qwen_classification": "footrest",
+      "qwen_reasoning": "The object has a distinct shape with a curved, elongated body and two prominent turquoise-colored pads or platforms on top. The lower part appears to be a white or light gray base with a structural design that suggests it is meant to be held or used in a specific way. This form factor is characteristic of a footrest or a small platform designed for ergonomic support, possibly for use in a chair or as a foot support for a specific activity. The turquoise pads are likely designed for comfort or grip. The overall design does not resemble footwear, furniture, or common household items. It is most consistent with a specialized footrest or a small balance board/ergonomic support device."
+    },
+    {
+      "asset_name": "gso_Room_Essentials_Kitchen_Towels_16_x_26_2_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8629,
+      "qwen_classification": "mat",
+      "qwen_reasoning": "The object appears to be a folded, textured fabric item. The surface has a distinct grid-like or ribbed pattern, suggesting it might be a type of mat, towel, or protective covering. The way it is folded and the visible texture are consistent with materials used for cushioning or grip, such as a yoga mat, exercise mat, or a specialized floor mat. However, without more context or a clearer view of the entire object, it is difficult to definitively classify it. The object could also be a folded piece of carpet or a specialized industrial mat, but the most likely interpretation is a folded mat of some kind."
+    },
+    {
+      "asset_name": "gso_SUPERSTAR_CLR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8136,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a shoe, specifically a sneaker, based on its shape, sole, and visible lacing system. The design features a dark green upper with three orange stripes, which is characteristic of a specific brand of athletic footwear. The view is a side profile showing the heel, midsole, and part of the upper. The texture and form are consistent with a casual or athletic sneaker."
+    },
+    {
+      "asset_name": "gso_SIT_N_WALK_PUPPY",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8106,
+      "qwen_classification": "toy car",
+      "qwen_reasoning": "The object is a small, white, toy-like vehicle with a rounded body, two wheels, and a handle or loop at the front. It has a red detail on the front and a small orange fin or tail on top. The design suggests it is a pull-along toy, likely for children, possibly shaped like a mouse or rabbit given the ears and tail-like feature. The presence of wheels and a handle indicates it is meant to be pulled or pushed along the floor."
+    },
+    {
+      "asset_name": "gso_Rubbermaid_Large_Drainer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8297,
+      "qwen_classification": "collapsible bottle rack",
+      "qwen_reasoning": "The object appears to be a collapsible or foldable rack, likely for holding items such as bottles, cans, or small containers. It has a grid-like structure with multiple vertical supports and horizontal bars, forming compartments. The top section is a long, rectangular tray with several compartments, suggesting it's designed to hold multiple items. The structure is made of thin, interconnected metal or plastic rods, allowing it to be folded or collapsed for storage. This design is common in kitchen or utility racks, such as a bottle rack or a collapsible storage organizer."
+    },
+    {
+      "asset_name": "gso_SAMe_200_KX7ZmOw47co",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8645,
+      "qwen_classification": "box",
+      "qwen_reasoning": "The object is a rectangular box with printed text and branding. The visible text includes \"SAM-200\" and \"200\" in a prominent font, along with other smaller text and a logo. The design suggests it is commercial packaging, likely for a product. The style and layout are typical of consumer goods packaging, such as for a product like a notebook, stationery, or small electronic device. The presence of a logo and product name indicates it is manufactured goods packaging. The object is clearly a box, not a loose item."
+    },
+    {
+      "asset_name": "gso_SANDWICH_MEAL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8448,
+      "qwen_classification": "container lid",
+      "qwen_reasoning": "The object appears to be a circular, flat item with a slightly raised rim, resembling a lid or cover. It has a brownish, possibly cardboard or paperboard material texture. There is a small, square-shaped printed mark or logo near the center. The shape and material suggest it could be a lid for a container, such as a takeout container, a food container, or a small box. The partial view and the way it's cropped make it difficult to be certain about the exact use, but the most plausible classification is a container lid."
+    },
+    {
+      "asset_name": "gso_SLACK_CRUISER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8175,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is black and has a curved, elongated shape with a distinct heel and toe area, consistent with the sole of a shoe. The presence of a small green tag or detail at the heel suggests it may be a branded or decorative element. The overall form and contours strongly indicate it is the bottom part of a footwear item, likely a sneaker or athletic shoe, given the typical design of shoe soles. The white background is masked, so only the object itself is visible, confirming it is a shoe sole."
+    },
+    {
+      "asset_name": "gso_SAPPHIRE_R7_260X_OC",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8494,
+      "qwen_classification": "electronics packaging",
+      "qwen_reasoning": "The object is a rectangular box with a predominantly black and red color scheme. It features text, symbols, and icons typical of product packaging, including what appears to be a logo (possibly 'SUNNY' or similar) on the side. The layout includes multiple small icons and paragraphs of text, suggesting it's packaging for an electronic device or component. The design and labeling are consistent with product boxes for consumer electronics, such as a graphics card, motherboard, or similar computer hardware. The red accent on the side and the overall aesthetic are common in tech product packaging."
+    },
+    {
+      "asset_name": "gso_Santa_Cruz_Mens_YmsMDkFf11Z",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8061,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a single, brown, slip-on shoe viewed from the bottom, highlighting the tread pattern on the sole. The shape, material appearance, and tread design are consistent with a casual or work-style shoe, such as a loafer or slip-on sneaker. The object is clearly identifiable as footwear, and the view is focused on the sole, which is typical for this type of shoe. There are no ambiguous features that would prevent confident classification."
+    },
+    {
+      "asset_name": "gso_Room_Essentials_Mug_White_Yellow",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8569,
+      "qwen_classification": "kettle",
+      "qwen_reasoning": "The object shown is a bright yellow, curved item with a handle-like structure on top. The shape and handle suggest it is designed to be held and carried. This form factor is characteristic of a kettle, particularly a teapot or a small electric kettle, which often have a handle for pouring and a rounded body. The glossy finish and color are common in modern kitchenware. While it could be a mug with a handle, the overall shape is more consistent with a kettle or teapot, which typically has a spout (not visible here) and a larger, more rounded body for holding liquid. Given the visible features, the most confident classification is a kettle or teapot."
+    },
+    {
+      "asset_name": "gso_Santa_Cruz_Mens_umxTczr1Ygg",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7859,
+      "qwen_classification": "slip-on shoe",
+      "qwen_reasoning": "The object is a light-colored slip-on shoe, likely a casual or canvas-style shoe. The visible features include the upper part of the shoe, a white stitching line along the edge, and the interior lining which shows some text (possibly a brand name). The design is simple and lacks laces, consistent with a slip-on style. The material appears to be fabric or canvas, and the overall shape is typical of a casual shoe worn for everyday use."
+    },
+    {
+      "asset_name": "gso_Samoa_onepiece",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8223,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a dark brown upper with visible stitching and a pattern of parallel stripes on the side. The sole is multi-toned, with a darker section at the heel and a lighter section at the toe. The overall design, including the shape and the stripe pattern, is characteristic of a running or training shoe. The brand name 'ADIDAS' is visible on the side, confirming it is a branded athletic shoe."
+    },
+    {
+      "asset_name": "gso_STACKING_BEAR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8576,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object appears to be a colorful, segmented toy with a head-like structure at one end and a tail-like structure at the other. The head has a large, cartoonish eye, suggesting it is designed for children. The body is composed of multiple colored segments (yellow, green, blue, purple, red), which is typical of a flexible, bendable toy. The overall shape and design strongly resemble a classic children's toy known as a 'rainbow caterpillar' or 'flexible snake toy'."
+    },
+    {
+      "asset_name": "gso_Samsung_CLTC406S_Toner_Cartridge_Cyan_1pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8447,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a dark blue rectangular box with printed text and symbols on its surface. The visible text appears to be in a language using the Latin alphabet, and there are several small icons or symbols near the bottom edge. The shape and labeling suggest it is a product packaging box, likely for an electronic device, software, or similar consumer item. The perspective is angled, showing two sides of the box. The lack of clear branding or specific product identification makes a precise classification difficult, but the overall form and features are consistent with a standard retail product box."
+    },
+    {
+      "asset_name": "gso_SNAIL_MEASURING_TAPE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7977,
+      "qwen_classification": "kite toy",
+      "qwen_reasoning": "The object has a distinct shape with a green central body, red circular ends, and a small yellow bird-like figure on top. It also has a white strap or handle extending downward. This design is characteristic of a traditional children's toy known as a 'kite' or 'kite-shaped toy' that is often used for pulling or as a pull-along toy. The bird-like figure on top is a common decorative element on such toys. The overall structure suggests it is meant to be pulled by a string or handle, which is consistent with kite toys or pull-along toys designed for children."
+    },
+    {
+      "asset_name": "gso_Schleich_Hereford_Bull",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8277,
+      "qwen_classification": "cow",
+      "qwen_reasoning": "The object in the image is a four-legged animal with a brown and white coat, a visible head, and a body posture that suggests movement or jumping. The shape, coloration, and overall form are consistent with a cow. The animal is captured mid-air, which is a dynamic pose often seen in animations or action shots of livestock. The segmentation from the background confirms it is a single object, and the visual details (hooves, body shape, fur pattern) are characteristic of a bovine animal."
+    },
+    {
+      "asset_name": "gso_Schleich_Bald_Eagle",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8697,
+      "qwen_classification": "eagle",
+      "qwen_reasoning": "The object is a bird of prey, likely an eagle, shown in mid-flight with its wings spread. Key features include a white head and neck, a yellow beak, and dark brown/black body and wing feathers. The bird is carrying a small animal (possibly a fox or similar mammal) in its talons, which is consistent with predatory behavior. The image appears to be a digital rendering or low-resolution 3D model, but the biological features are clearly identifiable as those of a large raptor."
+    },
+    {
+      "asset_name": "gso_Santa_Cruz_Mens_G7kQXK7cIky",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8241,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows the bottom sole of a footwear item. Key features include a textured tread pattern designed for grip, a distinct heel area, and a visible brand logo or marking (appearing as '301' or similar) embossed on the sole. The overall shape and construction are consistent with a casual or athletic shoe, possibly a slip-on style given the lack of visible laces or straps. The material appears to be rubber or a similar synthetic polymer commonly used in shoe soles. The view is a direct bottom-up perspective, focusing on the sole's design and wear characteristics."
+    },
+    {
+      "asset_name": "gso_Schleich_S_Bayala_Unicorn_70432",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8417,
+      "qwen_classification": "unicorn figurine",
+      "qwen_reasoning": "The object is a stylized, light-colored horse with a single horn on its forehead, which is a defining characteristic of a unicorn. It has a flowing mane and tail, and is depicted in a dynamic, galloping pose. The presence of the horn, combined with the horse-like body, clearly identifies it as a unicorn, a mythical creature. The object appears to be a figurine or toy, given its smooth, painted surface and simplified features."
+    },
+    {
+      "asset_name": "gso_Smith_Hawken_Woven_BasketTray_Organizer_with_3_Compartments_95_x_9_x_13",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8767,
+      "qwen_classification": "basket",
+      "qwen_reasoning": "The object is a woven basket with a square or rectangular shape. It appears to be made from natural fibers, such as wicker or rattan, and has a textured, interlaced pattern. The construction suggests it is designed for storage or decorative purposes. The object is viewed from an angled perspective, showing its three-dimensional form."
+    },
+    {
+      "asset_name": "gso_Saccharomyces_Boulardii_MOS_Value_Size",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8402,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a white plastic bottle with a label that has blue and yellow text and graphics. The label includes text that appears to read \"Sodium Bicarbonate\" and \"5g\". There is also a graphic of a cartoon character (possibly a dinosaur or similar creature) and a depiction of a molecular structure. The bottle has a white cap and is slightly tilted. This is consistent with a supplement or medication bottle, specifically one containing sodium bicarbonate (baking soda), which is commonly sold as an over-the-counter remedy or sports supplement. The design and labeling are typical for consumer health products."
+    },
+    {
+      "asset_name": "gso_Schleich_Lion_Action_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8259,
+      "qwen_classification": "lion statue",
+      "qwen_reasoning": "The object has the distinct physical characteristics of a lion: a muscular body, a tan-colored coat, a darker mane around the head and neck, and four legs with black paws. The posture suggests it is in motion, possibly walking or trotting. The object appears to be a model or statue rather than a live animal, given its slightly stylized appearance and the way it is presented against a white background. However, based on its clear anatomical features, it is confidently identifiable as a lion."
+    },
+    {
+      "asset_name": "gso_Shurtape_Tape_Purple_CP28",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8566,
+      "qwen_classification": "tape roll",
+      "qwen_reasoning": "The object is a roll of tape, identifiable by its cylindrical shape, the visible adhesive side, and the label on the core. The label clearly shows the brand name 'Shurtape', which is a manufacturer of industrial and packaging tapes. The purple color is likely a specific type or variant of their product line. The object is a roll of adhesive tape, commonly used for sealing, bundling, or temporary fastening."
+    },
+    {
+      "asset_name": "gso_Schleich_African_Black_Rhino",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8186,
+      "qwen_classification": "rhino calf",
+      "qwen_reasoning": "The object in the image is a small, grayish-brown animal with a stout body, short legs, and a rounded head. It appears to be lying on its back with its legs splayed out. The overall shape and features are consistent with a young rhinoceros, possibly a calf. The texture and coloration suggest it is a model or a digital rendering rather than a live animal, but the form is unmistakably that of a rhino. The posture is unusual for a rhino, which typically does not lie on its back in this manner, but the body structure is clearly identifiable."
+    },
+    {
+      "asset_name": "gso_STACKING_RING",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8330,
+      "qwen_classification": "rattle",
+      "qwen_reasoning": "The object consists of a series of colorful, circular rings arranged in a curved, arch-like formation. The rings are of varying colors (red, orange, yellow, green, blue, purple, and beige) and appear to be connected or stacked together. The shape and arrangement suggest it is a toy designed for grasping or pulling, commonly known as a rattle or a stacking toy. The curved shape and the way the rings are connected indicate it is likely meant to be held and shaken, which is typical for infant or toddler toys. The object is not a single solid piece but a sequence of rings, which is characteristic of a rattle or a similar developmental toy."
+    },
+    {
+      "asset_name": "gso_Sea_to_Summit_Xl_Bowl",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8428,
+      "qwen_classification": "button",
+      "qwen_reasoning": "The object is a circular, dark blue item with a raised rim and a slightly concave center. The shape and appearance are consistent with a button, specifically a push-button or a decorative button. The raised edge suggests it is designed to be pressed or to have a tactile feel. The dark center could be a recessed area or a different material, but the overall form strongly indicates a button. It does not resemble a wheel, a lid, or any other common object due to its simple, flat, circular design with a defined rim."
+    },
+    {
+      "asset_name": "gso_Sienna_Brown_Croc_Tieks_Patent_Leather_Crocodile_Print_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8093,
+      "qwen_classification": "beret",
+      "qwen_reasoning": "The object appears to be a piece of headwear, specifically a beret or a similar soft cap. It has a rounded, dome-like shape with a folded brim, and the material looks like fabric. The color is primarily brown with a darker trim or edge. The style is consistent with a military or casual beret, often worn by various groups including soldiers, artists, or as fashion accessory. The white areas are likely artifacts from the segmentation process, not part of the object."
+    },
+    {
+      "asset_name": "gso_Seagate_1TB_Backup_Plus_portable_drive_Silver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8458,
+      "qwen_classification": "battery",
+      "qwen_reasoning": "The object is a flat, rectangular item with rounded corners and a smooth, matte surface. It has printed text and symbols on its surface, including what appears to be regulatory markings (like CE) and possibly model or serial information. The shape and labeling are characteristic of a lithium-ion battery, commonly used in electronic devices such as smartphones, tablets, or laptops. The gold or beige color is typical for some battery casings. The object is not a phone, tablet, or laptop itself, but rather a component that would be inside one."
+    },
+    {
+      "asset_name": "gso_Sonny_School_Bus",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8865,
+      "qwen_classification": "toy car",
+      "qwen_reasoning": "The object is a toy vehicle, specifically a car or truck, constructed from interlocking plastic blocks. It has a yellow body with a black wheel visible, and a blue piece on the side. On top, there is a stack of red and blue blocks, which are characteristic of building blocks like LEGO or similar toys. The overall shape and construction suggest it is a child's toy designed for imaginative play and building."
+    },
+    {
+      "asset_name": "gso_Sony_Downloadable_Loops",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8348,
+      "qwen_classification": "electronics box",
+      "qwen_reasoning": "The object is a rectangular box with a dark brown or black background and colorful abstract graphics in purple, pink, and blue. There is text on the side, including what appears to be the brand name 'SONY' and product information such as 'Compact Disc & DVD Player'. This is characteristic packaging for an electronic device, specifically a Sony DVD player. The design and text confirm it is a consumer electronics product box."
+    },
+    {
+      "asset_name": "gso_Snack_Catcher_Snack_Dispenser",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8573,
+      "qwen_classification": "sippy cup",
+      "qwen_reasoning": "The object is a small, blue plastic cup with green handles on either side. It has a cartoonish design with colorful illustrations, including what appear to be planets and stars, suggesting it is intended for children. The shape is cylindrical with a slightly tapered bottom, and the handles are curved outward, typical of sippy cups designed for young children to hold and drink from. The overall appearance matches that of a child's drinking cup or sippy cup."
+    },
+    {
+      "asset_name": "gso_Shurtape_30_Day_Removal_UV_Delct_15",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8499,
+      "qwen_classification": "painter's tape",
+      "qwen_reasoning": "The object is a roll of tape, identifiable by its cylindrical shape, the visible adhesive backing with printed text, and the way the tape is wound. The purple color is a common variant for painter's tape or decorative tape. The printed text on the backing suggests it is a commercial product with branding or specifications. This is not a generic roll of tape but a specific type, likely painter's tape or masking tape, given the context of the adhesive backing and the common use of purple for such products."
+    },
+    {
+      "asset_name": "gso_Shurtape_Gaffers_Tape_Silver_2_x_60_yd",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8424,
+      "qwen_classification": "tape roll",
+      "qwen_reasoning": "The object shown is a roll of tape. It has a cylindrical shape with a visible core in the center and layers of tape wound around it. The tape appears to be black on the outer surface and possibly a lighter color (like beige or tan) on the inner layers or core. This is a common form factor for adhesive tape used in various applications such as sealing, bundling, or repair. The object is clearly identifiable as a roll of tape, and there are no ambiguous features that would suggest it is something else."
+    },
+    {
+      "asset_name": "gso_Seagate_1TB_Wireless_Plus_mobile_device_storage",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8469,
+      "qwen_classification": "battery",
+      "qwen_reasoning": "The image shows a close-up of a black rectangular object with printed text and symbols on its surface. The text appears to be technical specifications, safety certifications (like CE marking), and possibly model or serial numbers. This type of labeling is commonly found on electronic devices, particularly batteries or power packs. The shape and labeling strongly suggest it is a battery, likely for a portable electronic device such as a laptop, tablet, or phone. The object is not a complete device but rather a component, specifically a battery, as indicated by the labeling and typical design."
+    },
+    {
+      "asset_name": "gso_Sonicare_2_Series_Toothbrush_Plaque_Control",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8832,
+      "qwen_classification": "toothbrush box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding visible. The text \"Philips Sonicare\" is clearly printed on the side, which is a well-known brand for electric toothbrushes. The box also features an image of a toothbrush and has a green label indicating it contains 2 items. This is consistent with packaging for replacement toothbrush heads or a complete toothbrush system. The object is clearly a product box for a consumer electronic dental care item."
+    },
+    {
+      "asset_name": "gso_Seagate_Archive_HDD_8_TB_Internal_hard_drive_SATA_6Gbs_35_ST8000AS0002",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8676,
+      "qwen_classification": "hard disk drive",
+      "qwen_reasoning": "The object shown is a rectangular electronic device with a green circuit board visible on one side and a black casing. There are small white circular components and a flexible orange cable connecting parts of the board. This appearance is characteristic of a hard disk drive (HDD), which is a data storage device commonly used in computers. The green board is likely the printed circuit board (PCB) that contains the controller and other electronics, while the black casing houses the spinning platters and motor. The orientation and visible components are consistent with the internal structure of an HDD."
+    },
+    {
+      "asset_name": "gso_SpiderMan_Titan_Hero_12Inch_Action_Figure_5Hnn4mtkFsP",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8300,
+      "qwen_classification": "spider-man",
+      "qwen_reasoning": "The object is a stylized, cartoon-like figure wearing a red and blue costume with a spider emblem on the chest. The pose suggests dynamic movement, such as swinging or falling. The costume design, including the web pattern on the suit and the iconic mask, is unmistakably that of the superhero Spider-Man. The low-polygon, pixelated rendering indicates it is likely from an older video game or digital animation."
+    },
+    {
+      "asset_name": "gso_Sperry_TopSider_pSUFPWQXPp3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8230,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a brown, leather-like boot with a thick, block heel and a visible sole. The design suggests it is a type of ankle boot or wedge boot, commonly worn for casual or fashion purposes. The material appears to be suede or nubuck, and the construction includes stitching and a strap detail around the ankle area. The perspective is a side view, showing the profile of the boot from the heel to the top of the shaft."
+    },
+    {
+      "asset_name": "gso_Seagate_1TB_Backup_Plus_portable_drive_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8570,
+      "qwen_classification": "book",
+      "qwen_reasoning": "The object appears to be a rectangular, dark purple item with a slightly raised spine and a visible bottom edge. The shape and form suggest it is a bound object, likely a book or a notebook. The surface has a smooth, possibly leather-like texture, and there is a small, indistinct gold or yellow mark near the bottom, which could be a logo or decorative element. The way it is angled and the shadowing suggest it is a physical object with some thickness. Given the context and appearance, it is most likely a book or a notebook, though without more detail it is difficult to be certain of the exact type."
+    },
+    {
+      "asset_name": "gso_Seagate_1TB_Backup_Plus_portable_drive_for_Mac",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8539,
+      "qwen_classification": "power bank",
+      "qwen_reasoning": "The object is a white, rectangular device with a smooth surface. On its surface, there are small printed markings, including what appears to be regulatory symbols (like a CE mark) and text, which is typical for electronic devices. The shape and markings suggest it is a portable electronic gadget, likely a power bank or a similar battery pack, given its common form factor and labeling. The object is not a phone, laptop, or other clearly identifiable device due to the lack of visible ports, screens, or distinctive features. However, the presence of regulatory text and symbols strongly indicates it is an electronic device intended for consumer use."
+    },
+    {
+      "asset_name": "gso_Schleich_Spinosaurus_Action_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8154,
+      "qwen_classification": "dinosaur",
+      "qwen_reasoning": "The object is a bipedal dinosaur with a long tail, a slender body, and a head that is raised upward. It has two forelimbs and two hindlimbs, with the hindlimbs appearing longer and more powerful for locomotion. The posture suggests it is in motion, possibly running or leaping. The overall morphology, including the body shape, limb structure, and tail, is consistent with a theropod dinosaur, specifically resembling a small to medium-sized carnivorous theropod like a Velociraptor or a similar dromaeosaurid. The object is clearly a digital rendering or model of a dinosaur, not a real animal or inanimate object."
+    },
+    {
+      "asset_name": "gso_SpiderMan_Titan_Hero_12Inch_Action_Figure_oo1qph4wwiW",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7934,
+      "qwen_classification": "spider-man",
+      "qwen_reasoning": "The object is a stylized, cartoon-like figure wearing a red and blue costume with web patterns, a mask, and gloves. The pose is dynamic, suggesting movement or action. This is clearly a representation of the superhero Spider-Man, identifiable by his iconic costume design and posture. The object is not a real-world item but a digital rendering or illustration of a fictional character."
+    },
+    {
+      "asset_name": "gso_Sony_Acid_Music_Studio",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8437,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular box with printed text and images on its surface. It has a green header section at the top with text, followed by a white body containing paragraphs, small images (including people and what appears to be a product or diagram), and a logo in the bottom left corner. The overall appearance is consistent with a product packaging box, likely for a software or electronic product, given the layout and content. The box has visible edges and a three-dimensional form, suggesting it is a physical container."
+    },
+    {
+      "asset_name": "gso_Shark",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8023,
+      "qwen_classification": "shark",
+      "qwen_reasoning": "The object appears to be a dark-colored, stylized representation of a shark. It has a streamlined, elongated body with a pointed snout, visible gill slits, and a tail fin. The shape is consistent with a shark's silhouette, and the dark coloration is typical for such depictions. The object is likely a toy, figurine, or digital rendering rather than a real animal, given its simplified, somewhat pixelated appearance and the white background indicating it's a cropped image. The overall form strongly suggests a shark, specifically resembling a great white shark or similar predatory species."
+    },
+    {
+      "asset_name": "gso_Sootheze_Toasty_Orca",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8081,
+      "qwen_classification": "orca",
+      "qwen_reasoning": "The object has a streamlined, torpedo-like body shape with a distinct black and white color pattern. The black markings are on the dorsal (top) side and the flippers, while the ventral (bottom) side is white. This coloration and body shape are characteristic of an orca (killer whale), which is a type of dolphin. The object appears to be a simplified, stylized representation, possibly a toy or digital rendering, but the key identifying features are present."
+    },
+    {
+      "asset_name": "gso_Sorry_Sliders_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8350,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The image displays the front of a board game box. The title \"Sliders\" is prominently featured in large, stylized orange letters. Above the title is a large blue megaphone graphic, and below it are cartoon illustrations of various characters, including a dog, a cat, and a person. The box also has a green spine with the word \"Sliders\" written vertically. This is clearly the packaging for a board game, likely a family or children's game given the cartoonish art style."
+    },
+    {
+      "asset_name": "gso_Sootheze_Cold_Therapy_Elephant",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8778,
+      "qwen_classification": "elephant headband",
+      "qwen_reasoning": "The object appears to be a headband or hair accessory shaped like an elephant's head. It has two large, rounded ears characteristic of an elephant, and a small red bow tied around the base of the ears. The overall form suggests it is designed to be worn on the head, likely as a decorative item. The material looks soft and plush, possibly fabric or faux fur, and the shape is stylized rather than realistic. The cropped view shows only part of the object, but the key features are clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Simon_Swipe_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8271,
+      "qwen_classification": "gaming controller",
+      "qwen_reasoning": "The object is a circular, multi-colored device with a central component that appears to be a speaker or sound module. It has four distinct colored segments (red, blue, yellow, green) arranged around the perimeter, which is characteristic of a game controller or interactive toy. The design strongly resembles the 'Wii Wheel' or 'Wii Wheel Controller' used with Nintendo Wii consoles, which is a steering wheel-style controller with colored directional pads. The central part has a textured surface and what looks like a logo or branding, consistent with gaming peripherals. The overall shape and segmented color scheme are definitive indicators of this type of controller."
+    },
+    {
+      "asset_name": "gso_Sperry_TopSider_tNB9t6YBUf3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8468,
+      "qwen_classification": "arm guard",
+      "qwen_reasoning": "The object appears to be a brown, leather-like item with a curved, tubular shape. It has visible stitching or seams along its length and a slightly flared opening at one end. The overall form and material suggest it is a type of protective gear, specifically an arm guard or bracer, commonly used in sports or historical reenactments. The shape is consistent with a forearm or upper arm protector, designed to cover and shield the arm. The material and construction are typical of leather or synthetic leather used in such gear."
+    },
+    {
+      "asset_name": "gso_Shaxon_100_Molded_Category_6_RJ45RJ45_Shielded_Patch_Cord_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8855,
+      "qwen_classification": "cable",
+      "qwen_reasoning": "The object is a coiled, white, flexible item with a uniform cylindrical shape and a smooth surface. The way it is coiled and the visible texture suggest it is made of a soft, pliable material, likely plastic or rubber. The object appears to be a cable or cord, possibly for electrical or data transmission, given its typical appearance in such contexts. The ends are not clearly visible, but the overall form is consistent with a cable reel or a long cable stored in a coil. There are no visible connectors or distinct features to identify it as a specific type of cable (e.g., Ethernet, power, etc.), so the most accurate general classification is 'cable'."
+    },
+    {
+      "asset_name": "gso_Swiss_Miss_Hot_Cocoa_KCups_Milk_Chocolate_12_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8655,
+      "qwen_classification": "diaper box",
+      "qwen_reasoning": "The object is a rectangular, light blue box with a printed image on its front. The image appears to show a baby or infant, and there is a logo visible that resembles the brand 'Pampers'. The box has text and design elements typical of consumer product packaging. Given the imagery and branding, this is most likely a package of baby diapers or related infant care products."
+    },
+    {
+      "asset_name": "gso_TOP_TEN_HI_60KlbRbdoJA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8427,
+      "qwen_classification": "high-top sneaker",
+      "qwen_reasoning": "The object is a high-top sneaker with a dark blue upper, white laces, and white stripes along the side. It has a white rubber sole and a visible logo on the tongue. The design and construction are typical of athletic or casual footwear. The object is clearly identifiable as a shoe, specifically a high-top sneaker."
+    },
+    {
+      "asset_name": "gso_Starstruck_Tieks_Glittery_Gold_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8353,
+      "qwen_classification": "high-heeled shoe",
+      "qwen_reasoning": "The object appears to be a single shoe, specifically a high-heeled shoe, viewed from a side angle. It has a distinct heel structure, a curved sole, and a decorative upper part with a patterned or textured surface. The coloration is primarily yellowish with a teal or greenish trim along the edge. The shape and construction are consistent with formal or dress shoes, possibly for women. The white areas are masked background, not part of the object."
+    },
+    {
+      "asset_name": "gso_Super_Mario_3D_World_Wii_U_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8455,
+      "qwen_classification": "video game case",
+      "qwen_reasoning": "The object appears to be a video game case, likely for a Nintendo Switch game, based on the visible artwork and layout. The cover features colorful characters and a title that reads \"Explore a whole new world!\" which is typical of game packaging. The blue plastic casing and the angled perspective suggest it is a physical game cartridge or case. The design elements, including the character illustrations and promotional text, are consistent with video game marketing materials."
+    },
+    {
+      "asset_name": "gso_Sleep_Optimizer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8445,
+      "qwen_classification": "sleep mask",
+      "qwen_reasoning": "The object is a blue rectangular box with visible text and graphics. The text includes the brand name \"Jacobs\" and the word \"Sleep\" followed by \"izer\" (likely \"Sleepizer\"), suggesting it is a product related to sleep. The design features stars and clouds, reinforcing the sleep theme. The object appears to be a retail package for a consumer product, likely a sleep aid such as a sleep mask, eye mask, or sleep-related supplement. The visible portion shows the top and side of the box, with a beige or light brown bottom section, possibly indicating the product's color or a design element. Based on the branding and visual cues, this is most likely a sleep mask or sleep aid product."
+    },
+    {
+      "asset_name": "gso_Star_Wars_Rogue_Squadron_Nintendo_64",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8433,
+      "qwen_classification": "video game cartridge",
+      "qwen_reasoning": "The object is a gray plastic cartridge with a label on the front. The label features artwork depicting a character in a dynamic pose, along with text and logos. The shape and design are characteristic of a video game cartridge for the Nintendo Game Boy Advance (GBA). The label includes the title \"Star Wars: Episode I - Racer\" and the Nintendo logo, confirming it is a GBA game cartridge. The cartridge has a distinct curved top and bottom, with a central slot for insertion into the console."
+    },
+    {
+      "asset_name": "gso_Squirrel",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8559,
+      "qwen_classification": "stuffed bear",
+      "qwen_reasoning": "The object appears to be a plush toy, specifically a bear. It has a brown, furry texture, rounded ears, and a visible snout with a small nose and whiskers. The bear is in a dynamic pose, possibly falling or tumbling, with its limbs bent and body angled. The material looks soft and stuffed, consistent with a stuffed animal. The white areas on its chest and inner ears suggest stitching or fabric details typical of plush toys. The overall shape and features strongly indicate it is a stuffed bear toy."
+    },
+    {
+      "asset_name": "gso_Super_Mario_3D_World_Deluxe_Set",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8127,
+      "qwen_classification": "handheld gaming console",
+      "qwen_reasoning": "The object is a handheld electronic device with a screen displaying a colorful image, and physical buttons below the screen. The shape and layout are characteristic of a portable gaming console. The screen is tilted upward, and the device has a dark casing with visible controls, including directional pads and action buttons. This matches the design of the Nintendo DS, a well-known handheld gaming system from the mid-2000s. The screen shows a game in progress, further supporting this identification."
+    },
+    {
+      "asset_name": "gso_TERREX_FAST_R",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8382,
+      "qwen_classification": "protective knee pad",
+      "qwen_reasoning": "The object is a protective piece of gear with a segmented, padded design, featuring blue and black colors with some white or silver accents. It has straps and appears to be designed to cover and protect a specific body part, likely the knee or thigh. The shape and construction are consistent with protective gear used in sports such as motocross, mountain biking, or other action sports where impact protection is needed. The presence of multiple padded sections and adjustable straps supports this classification."
+    },
+    {
+      "asset_name": "gso_Tag_Dishtowel_18_x_26",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8345,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a folded textile with a pattern of alternating green and beige stripes. The texture appears woven or ribbed, and the way it is folded suggests it is a flexible, flat item. Given its appearance and common uses, it is most likely a towel, specifically a bath towel or hand towel, due to its size and pattern. The folds and the material's appearance are consistent with typical towel construction."
+    },
+    {
+      "asset_name": "gso_TZX_Runner",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8047,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker. It has a distinct shape with a visible sole, upper structure, and lacing area. The color scheme includes purple, black, and white, which is common for athletic or casual sneakers. The segmented view shows the side profile of the shoe, including the midsole and outsole. The texture and contours are consistent with footwear designed for walking or running."
+    },
+    {
+      "asset_name": "gso_TERREX_FAST_X_GTX",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8422,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a dark-colored, possibly black, athletic shoe. It has the characteristic shape of a sneaker, with a visible sole, upper structure, and what looks like lacing or stitching details. The perspective is a side or angled view, showing the profile of the shoe. The texture and contours suggest it is made of fabric or synthetic materials typical for athletic footwear. While the image is low-resolution and pixelated, the overall silhouette is consistent with a shoe, specifically a casual or athletic sneaker."
+    },
+    {
+      "asset_name": "gso_TWISTED_PUZZLE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8473,
+      "qwen_classification": "tangram puzzle",
+      "qwen_reasoning": "The object is a set of colorful geometric shapes arranged in a specific pattern, resembling a tangram puzzle. The shapes are triangular, square, and parallelogram-shaped, and are made of a solid material, likely plastic or wood. They are contained within a white tray or case, which suggests it is a puzzle or educational toy designed for assembly or spatial reasoning. The arrangement of the pieces is not random but forms a recognizable figure, which is typical of tangram puzzles."
+    },
+    {
+      "asset_name": "gso_Super_Mario_Kart_Super_Nintendo_Entertainment_System",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8384,
+      "qwen_classification": "video game cartridge",
+      "qwen_reasoning": "The object in the image is a rectangular cartridge with a distinct shape and design. It has a plastic casing with visible ridges and a label area on the front. This form factor is characteristic of video game cartridges used for consoles such as the Nintendo Entertainment System (NES) or similar systems from the 1980s and 1990s. The cartridge appears to be a standard game cartridge, designed to be inserted into a console to play a video game. The color is a dark gray or purple, which is common for many game cartridges of that era."
+    },
+    {
+      "asset_name": "gso_Spritz_Easter_Basket_Plastic_Teal",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8740,
+      "qwen_classification": "stool",
+      "qwen_reasoning": "The object is a solid, cylindrical shape with a smooth top surface and a scalloped or wavy lower edge. The material appears to be plastic, given the glossy finish and uniform color. The scalloped base suggests it is designed to sit stably on a surface, possibly as a decorative or functional item. This shape is characteristic of a small stool or footstool, often used as a decorative accent or for minor seating purposes. The lack of legs or visible structural supports implies it is a single-piece molded object, which is common for plastic stools. The design is simple and modern, with no visible branding or additional features."
+    },
+    {
+      "asset_name": "gso_Squirt_Strain_Fruit_Basket",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8806,
+      "qwen_classification": "popsicle",
+      "qwen_reasoning": "The object appears to be a popsicle or ice pop, characterized by its bright yellow, semi-translucent frozen substance. It is partially encased in a bright green plastic holder or wrapper, which has a ribbed or slatted design typical of popsicle molds or holders. The shape of the frozen part is curved and tapered, consistent with how popsicles are typically formed. The green holder is likely the part that is held in the hand, and the yellow portion is the frozen treat itself. The cropped view shows only a portion of the object, but the combination of the frozen substance and the holder strongly suggests it is a popsicle."
+    },
+    {
+      "asset_name": "gso_TURBOPROP_AIRPLANE_WITH_PILOT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8766,
+      "qwen_classification": "skateboarder",
+      "qwen_reasoning": "The object appears to be a stylized, cartoonish representation of a person riding a skateboard. It features a simplified human-like figure with a round head, yellow torso, and red legs, positioned on a long, flat board with wheels underneath. The overall design is blocky and low-poly, suggesting it might be from a video game or 3D animation. The figure is leaning forward, which is typical for someone riding a skateboard. The object is clearly segmented from its background, with white pixels masking the surroundings."
+    },
+    {
+      "asset_name": "gso_TOP_TEN_HI",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8222,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The image shows a close-up view of the sole and heel area of a shoe. The sole is tan-colored with a textured pattern typical of rubber soles, and there is a visible heel counter. The upper part of the shoe, visible at the top of the image, is red with white stripes, suggesting a sporty or casual sneaker design. The perspective is from below, looking up at the shoe, which is a common way to display footwear. Based on these features, it is clearly a shoe, specifically a sneaker."
+    },
+    {
+      "asset_name": "gso_Tag_Dishtowel_Green",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8488,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object appears to be a folded textile with a pattern of green and white stripes. The texture and pattern suggest it is likely a piece of fabric, such as a towel, tablecloth, or decorative cloth. The way it is folded and the visible stitching or decorative elements along the stripes indicate it is a manufactured textile product, not a natural fiber or raw material. Given the context of the image (a cropped, segmented view), it is most likely a household or decorative textile item."
+    },
+    {
+      "asset_name": "gso_The_Coffee_Bean_Tea_Leaf_KCup_Packs_Jasmine_Green_Tea_16_count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8857,
+      "qwen_classification": "tea box",
+      "qwen_reasoning": "The object is a box of tea, specifically jasmine tea, as indicated by the text on the packaging. The box has a rectangular shape with visible branding, product name, and imagery related to tea. The design includes a yellow and green color scheme with floral motifs, typical for tea packaging. The text \"Jasmine Tea\" and \"Tea\" is clearly visible, confirming its identity as a tea product."
+    },
+    {
+      "asset_name": "gso_Tag_Dishtowel_Basket_Weave_Red_18_x_26",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8381,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a rectangular, soft-textured item with a pattern of alternating pink and white vertical stripes. The edges appear slightly frayed, which is characteristic of fabric items like towels or cloths. The material looks absorbent and plush, consistent with a towel or similar textile product. The way it is folded and the texture suggest it is meant for personal use, likely for drying or wiping. Given the pattern and texture, it is most likely a towel, possibly a bath towel or hand towel."
+    },
+    {
+      "asset_name": "gso_TROCHILUS_BOOST",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8398,
+      "qwen_classification": "athletic shoe sole",
+      "qwen_reasoning": "The image shows a close-up of the sole of a shoe, specifically highlighting the tread pattern. The visible features include a black rubber outsole with a distinct tread design, which is typical for athletic footwear. The shape and curvature suggest it is part of a shoe designed for movement, likely a sneaker or athletic shoe. The white areas in the image are background and not part of the object. Based on the tread pattern and overall structure, this is clearly a shoe sole, and given the context of the tread design, it is most likely an athletic shoe sole."
+    },
+    {
+      "asset_name": "gso_Threshold_Performance_Bath_Sheet_Sandoval_Blue_33_x_63",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8349,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a rectangular, folded item with a textured surface, consistent with the appearance of a towel. The deep blue color and the visible folds suggest it is made of a soft, absorbent fabric commonly used for towels. The way it is folded and the texture are characteristic of bath towels or hand towels."
+    },
+    {
+      "asset_name": "gso_Sushi_Mat",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8012,
+      "qwen_classification": "sushi rolling mat",
+      "qwen_reasoning": "The object appears to be a rectangular mat made of thin, parallel strips, likely bamboo or a similar natural material. The strips are woven or bound together, creating a grid-like pattern. The color is light beige or off-white, and the edges are slightly frayed or uneven, suggesting it is a flexible, possibly disposable or reusable mat. This structure is characteristic of a sushi rolling mat (makisu) used in Japanese cuisine to roll sushi, or a similar type of bamboo mat used for food preparation or as a placemat. The object is not a tool, container, or electronic device, but rather a flat, woven surface."
+    },
+    {
+      "asset_name": "gso_Supernatural_Ouija_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8335,
+      "qwen_classification": "DVD cover",
+      "qwen_reasoning": "The visible text fragments \"OUIJA\" and \"SUPERNATURAL\" are key identifiers. \"OUIJA\" is a well-known board game involving spirit communication, and \"SUPERNATURAL\" is a popular TV show and franchise. The dark, atmospheric design with a teal/blue color scheme and the phrase \"JOIN THE HUNT\" strongly suggest this is promotional material for the \"Supernatural\" TV show, specifically for its \"Ouija\" episode or crossover content. The object appears to be a box or cover art for a product related to the \"Supernatural\" franchise, likely a DVD, Blu-ray, or special edition release."
+    },
+    {
+      "asset_name": "gso_The_Scooper_Hooper",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8293,
+      "qwen_classification": "ice cream",
+      "qwen_reasoning": "The object appears to be a plate or bowl containing three scoops of ice cream. The scoops are distinct in color: one is purple, one is pink, and one is green. They are arranged on a yellowish plate with a decorative pattern. The object is presented at an angle, and the white background indicates it has been cropped and segmented from its original context. The visual characteristics strongly suggest it is a dessert item, specifically ice cream."
+    },
+    {
+      "asset_name": "gso_Tag_Dishtowel_Dobby_Stripe_Blue_18_x_26",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8504,
+      "qwen_classification": "fabric",
+      "qwen_reasoning": "The object appears to be a piece of fabric or textile with a distinct pattern. It features vertical stripes in varying shades of blue, suggesting a woven or printed design. The shape is irregular, with a curved cutout on the left side, which could indicate it's a fragment of a larger item like a scarf, cloth, or garment. The texture and pattern are consistent with textile materials, and the object is clearly segmented from its background. There are no features that would identify it as a specific manufactured product like a phone, bottle, or shoe."
+    },
+    {
+      "asset_name": "gso_Tetris_Link_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8905,
+      "qwen_classification": "video game box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with colorful graphics and text. It features images of what appear to be video game cartridges or similar media on its front panel, along with branding and design elements typical of a product package. The overall appearance strongly suggests it is a retail box for a video game or gaming-related product, likely from the 1980s or 1990s given the style. The box is angled, showing its top and front surfaces."
+    },
+    {
+      "asset_name": "gso_Threshold_Porcelain_Pitcher_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8577,
+      "qwen_classification": "pitcher",
+      "qwen_reasoning": "The object has a curved, bulbous body with a handle attached, and a spout at the top. This shape is characteristic of a pitcher or jug, designed for pouring liquids. The base appears to have some text or markings, which is common on ceramic or glass pitchers. The overall form and features strongly suggest it is a liquid container with a pouring mechanism."
+    },
+    {
+      "asset_name": "gso_Thomas_Friends_Wooden_Railway_Talking_Thomas_z7yi7UFHJRj",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8559,
+      "qwen_classification": "toy train",
+      "qwen_reasoning": "The object appears to be a toy train engine, specifically resembling Thomas the Tank Engine from the children's series. It has a blue and light blue color scheme with a yellow stripe, a front buffer beam, and three circular headlights. The design, including the shape of the cab and the front coupling, is characteristic of the Thomas the Tank Engine toy line. The object is shown from a side angle, highlighting its front and top features."
+    },
+    {
+      "asset_name": "gso_Tena_Pads_Heavy_Long_42_pads",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8672,
+      "qwen_classification": "incontinence pad package",
+      "qwen_reasoning": "The object is a packaged consumer product with branding and design elements. The visible text \"TENA\" is a well-known brand for incontinence products. The packaging includes a purple stripe with a graphic of a pad or tampon, and a green leaf-like design, which is typical for feminine hygiene or incontinence product packaging. The shape and structure suggest it is a box or package containing multiple units of the product. Based on the branding and visual cues, this is clearly a package of TENA incontinence pads or similar hygiene product."
+    },
+    {
+      "asset_name": "gso_Threshold_Bistro_Ceramic_Dinner_Plate_Ruby_Ring",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8281,
+      "qwen_classification": "plate",
+      "qwen_reasoning": "The object is an oval-shaped item with a smooth, flat surface and concentric red stripes around its rim. This design is characteristic of a plate, commonly used for serving food. The shape is not perfectly circular but elliptical, which is typical for some types of plates, especially those designed for specific serving or aesthetic purposes. The red stripes suggest it may be decorative or part of a specific dinnerware set. There are no other features to suggest it is anything other than a plate."
+    },
+    {
+      "asset_name": "gso_Tieks_Ballet_Flats_Diamond_White_Croc",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8137,
+      "qwen_classification": "sunglasses",
+      "qwen_reasoning": "The object appears to be a pair of sunglasses. It has a distinct frame shape with a curved top and a handle-like structure on the side, which is typical for sunglasses. The reflective surface and the overall form suggest it is designed to be worn on the face to shield the eyes from light. The white background isolates the object, but the visible contours and features are consistent with sunglasses."
+    },
+    {
+      "asset_name": "gso_Target_Basket_Medium",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8956,
+      "qwen_classification": "basket",
+      "qwen_reasoning": "The object appears to be a woven, basket-like structure with a distinct pattern of interlaced strands. The top surface shows a consistent, tight weave, while the side view reveals a layered or stacked construction, possibly indicating it is a container or part of a larger woven item. The material looks like natural fibers, such as rattan, wicker, or bamboo, commonly used in crafting baskets or similar household items. The curved edge suggests it might be a corner or partial view of a rectangular or square container. Given the visible weave and construction, it is most likely a basket or a section of a woven container."
+    },
+    {
+      "asset_name": "gso_Threshold_Bamboo_Ceramic_Soap_Dish",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8638,
+      "qwen_classification": "soap dish",
+      "qwen_reasoning": "The object is a small, rectangular, white dish with raised edges and a slightly concave interior. It appears to be made of ceramic or porcelain, given its smooth, glossy surface. The design includes two rectangular indentations on the bottom, which may be for holding items like soap or small utensils. This shape and design are typical of a soap dish or a small serving dish used in bathrooms or kitchens. The object is placed on a brownish surface, but the focus is on the dish itself."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Classic_2Eye_Boat_Shoe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8089,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a black slip-on shoe with a white sole and decorative red stitching or lacing around the front. It has a rounded toe and appears to be a casual or dress shoe, possibly a loafer or moccasin style. The red elements are likely decorative, not functional laces, and the overall design suggests a formal or semi-formal footwear item."
+    },
+    {
+      "asset_name": "gso_Threshold_Hand_Towel_Blue_Medallion_16_x_27",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8658,
+      "qwen_classification": "decorative cloth",
+      "qwen_reasoning": "The object appears to be a folded piece of fabric with a floral pattern. The pattern consists of stylized flowers in shades of blue, green, and orange on a light blue background. The way it is folded and the texture suggest it is a textile item, possibly a napkin, tablecloth, or decorative fabric. The edges are slightly uneven, indicating it is not a rigid object. Given the pattern and the way it is presented, it is most likely a decorative cloth item."
+    },
+    {
+      "asset_name": "gso_Threshold_Porcelain_Serving_Bowl_Coupe_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8480,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a smooth, rounded, bowl-shaped container with a wide opening and curved sides. It appears to be made of a light-colored material, possibly ceramic or porcelain, and has a shallow depth. The shape and form are consistent with a typical serving bowl or cereal bowl used for food. There are no handles, lids, or other features that would suggest a different function. The object is clearly segmented from the background, and its form is unambiguous."
+    },
+    {
+      "asset_name": "gso_Tag_Dishtowel_Waffle_Gray_Checks_18_x_26",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8666,
+      "qwen_classification": "car floor mat",
+      "qwen_reasoning": "The object appears to be a textured, rectangular item with a grid-like pattern of small raised dots or bumps. The surface has a plaid or checkered design with alternating light and dark stripes. The material looks like fabric or a synthetic textile, possibly with a rubberized or grippy finish. The shape is somewhat irregular, with a cut-out or notch on the right side, suggesting it might be a custom-fitted item. This pattern and texture are commonly found on items like car floor mats, gym mats, or specialized non-slip mats. The overall appearance is consistent with a floor mat designed for grip and durability, likely for automotive or industrial use."
+    },
+    {
+      "asset_name": "gso_Threshold_Ramekin_White_Porcelain",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8795,
+      "qwen_classification": "bottle cap",
+      "qwen_reasoning": "The object is a circular, ridged cap with a smooth top surface and a slightly tapered edge. The ridges suggest it is designed to be screwed on or off, which is typical for bottle caps or jar lids. The material appears to be plastic or metal, and the color is a light brown or beige. Given the shape and ridges, it is most likely a bottle cap, possibly for a beverage or cosmetic product."
+    },
+    {
+      "asset_name": "gso_Tiek_Blue_Patent_Tieks_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8054,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has the distinct shape of a high-heeled shoe, with a pointed toe, a curved heel, and a visible sole. The color is a teal or turquoise, with a darker trim along the edge. The perspective is angled, showing the side and top of the shoe. The design suggests it is a formal or dress shoe, possibly a pump or stiletto, given the heel structure. The segmented white background confirms this is a focused view of the shoe itself."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Casco_Bay_Suede_1Eye",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8149,
+      "qwen_classification": "loafer",
+      "qwen_reasoning": "The object is a dark blue slip-on shoe with a rounded toe and a decorative tassel on the vamp. The construction appears to be a moccasin-style shoe, characterized by its soft, flexible upper and lack of laces. The visible stitching along the edge suggests a classic loafer or moccasin design. The overall shape and features are consistent with a casual, comfortable shoe often worn for everyday use."
+    },
+    {
+      "asset_name": "gso_Thomas_Friends_Wooden_Railway_Porter_5JzRhMm3a9o",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8373,
+      "qwen_classification": "toy train",
+      "qwen_reasoning": "The object appears to be a toy train engine. It has a cylindrical body with a rounded front, typical of locomotives. The color scheme includes blue, black, and yellow stripes, which is common for children's toy trains. There are visible details such as rivets or bolts on the top and side, and a small smokestack or chimney at the very front. The perspective is a close-up, angled view from the front-left, showing the front of the engine and part of its side. The segmented, cropped nature and the style suggest it is a toy rather than a real locomotive."
+    },
+    {
+      "asset_name": "gso_Threshold_Porcelain_Spoon_Rest_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8012,
+      "qwen_classification": "spoon",
+      "qwen_reasoning": "The object has a distinct shape with a rounded, shallow bowl at one end and a long, slender handle at the other. This form is characteristic of a spoon, specifically designed for scooping or serving. The smooth, uniform surface and lack of any visible markings or complex features suggest it is a simple, utilitarian spoon, likely made of plastic or ceramic. The perspective is a side view, showing the profile of the bowl and handle. This shape is commonly used for serving soups, sauces, or other liquids, or for eating soft foods."
+    },
+    {
+      "asset_name": "gso_Thomas_Friends_Wooden_Railway_Deluxe_Track_Accessory_Pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7412,
+      "qwen_classification": "cross",
+      "qwen_reasoning": "The object appears to be a wooden cross, likely a religious or symbolic item. It has a vertical beam and a horizontal beam intersecting it, forming the classic cross shape. The material looks like light-colored wood, and there are some markings or carvings visible on the vertical beam, possibly including a keyhole-shaped cutout near the top. The object is segmented from its background, which is white, indicating it is the focus of the image. The style and construction suggest it could be a decorative cross, a religious artifact, or part of a larger structure like a crucifix or a cross-shaped stand."
+    },
+    {
+      "asset_name": "gso_Threshold_Bead_Cereal_Bowl_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8672,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is a bowl-shaped container with a curved, open top and a textured, dimpled exterior surface. The interior appears to have a decorative pattern with gold and white accents, suggesting it may be a decorative or ceremonial bowl. The overall shape and features are consistent with a traditional or ornamental bowl, possibly used for serving food or as a decorative item. The dimpled texture on the exterior is reminiscent of some traditional Japanese or Asian ceramic bowls, but without more context, it's difficult to be certain of its exact cultural origin or specific use. However, the form is unmistakably that of a bowl."
+    },
+    {
+      "asset_name": "gso_Top_Paw_Dog_Bow_Bone_Ceramic_13_fl_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8502,
+      "qwen_classification": "pet bowl",
+      "qwen_reasoning": "The object is a round, shallow container with a smooth, glossy surface. It has a pink interior and a white exterior with decorative bone patterns, which are commonly associated with pet feeding. The shape and design strongly suggest it is a pet food or water bowl, likely for a dog or cat. The embossed bone design on the inside further supports this classification."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Stormbuck_Lite_Plain_Toe_Oxford",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8060,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a portion of a shoe, specifically the toe and side area. The visible materials include a brown leather-like upper and a darker sole or insole. The shape and curvature suggest it is part of a footwear item, likely a casual or dress shoe, given the smooth, polished appearance of the upper material. The cropped view focuses on the front and side, which is typical for showcasing shoe design details."
+    },
+    {
+      "asset_name": "gso_Threshold_Porcelain_Teapot_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8522,
+      "qwen_classification": "bowl",
+      "qwen_reasoning": "The object is circular and white, with a slightly raised rim and a small protrusion on one side. The bottom surface has printed text, including what appears to be a brand name ('CERAMIC HILL') and other markings, which is typical for a product base. The shape and features suggest it is a container or dish, possibly a small bowl or a lid. The protrusion could be a handle or a design element. Given the context and appearance, it is most likely a small ceramic or porcelain bowl or a similar dish, viewed from the bottom."
+    },
+    {
+      "asset_name": "gso_Top_Paw_Dog_Bowl_Blue_Paw_Bone_Ceramic_25_fl_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8861,
+      "qwen_classification": "tambourine",
+      "qwen_reasoning": "The object is circular with a flat top surface and a raised, dark blue rim. There is a small, embossed or printed logo or design in the center. This shape and construction are characteristic of a tambourine, a musical instrument with a drum-like body and jingles. The design is consistent with a small, handheld tambourine often used in folk or percussion music."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Casco_Bay_Canvas_SlipOn",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 7970,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a close-up of a bright orange object with a curved, open-top shape. The texture appears soft and fabric-like, and the visible interior suggests a hollow cavity. The shape and context strongly resemble the upper portion of a slip-on shoe, such as a sneaker or loafer, with the opening for the foot visible. The orange color is typical for athletic or casual footwear. The white background indicates the object has been cropped and isolated, which is consistent with the provided context."
+    },
+    {
+      "asset_name": "gso_Thomas_Friends_Woodan_Railway_Henry",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8011,
+      "qwen_classification": "gaming controller",
+      "qwen_reasoning": "The object is a bright green, elongated device with multiple circular components arranged in a row along its length. It has a distinct shape with a main body and a smaller attached section at one end. The design and appearance are consistent with a handheld electronic device, possibly a gaming controller or a specialized tool. The circular elements resemble buttons or dials, and the overall form factor suggests it is designed for handheld use. The color and style are reminiscent of certain types of gaming peripherals or educational toys, but without more context, it is difficult to be certain of its exact function. However, given the shape and components, it is most likely a type of controller or remote device."
+    },
+    {
+      "asset_name": "gso_Threshold_Porcelain_Coffee_Mug_All_Over_Bead_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8555,
+      "qwen_classification": "golf ball",
+      "qwen_reasoning": "The object is white and has a rounded, somewhat cylindrical shape with a textured surface. The texture appears to be a dimpled or pebbled pattern, which is common on golf balls. The object is not a complete sphere but appears to be a cropped view of a portion of a golf ball, possibly showing one side and part of the top or bottom. The dimpled texture is a key identifying feature of golf balls, designed to reduce drag and improve aerodynamics during flight. The object is not a full golf ball as shown in the image, but the visible portion strongly suggests it is part of a golf ball."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Casco_Bay_Canvas_Oxford",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8051,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a close-up view of the sole of a shoe. The sole has a textured, grid-like pattern, which is common for providing traction. The shape is curved and elongated, consistent with the bottom of a shoe designed for walking or casual wear. The material appears to be rubber or a similar synthetic compound. The white area at the top edge suggests the shoe's upper material, which is typically fabric or leather. Based on these features, this is clearly the bottom of a shoe, likely a casual or athletic shoe."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Heritage_2Eye_Boat_Shoe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8173,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object shown is a shoe, specifically a sneaker. It has a visible sole with a light-colored midsole and a darker outsole. The upper part appears to be made of dark blue or black material. A small green dot is visible on the midsole, which may be a brand logo or indicator. The overall shape and design are consistent with athletic or casual sneakers. The view is a side profile, showing the curvature of the sole and the heel area."
+    },
+    {
+      "asset_name": "gso_Tieks_Ballet_Flats_Electric_Snake",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 7926,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a high-top sneaker or athletic shoe. The visible portion shows a colorful, patterned upper with shades of purple, green, and black, along with a white midsole and a teal or light blue accent on the side. The shape, including the curved heel counter and the visible lacing area, is consistent with a sneaker design. The object is viewed from a side angle, showing the profile of the shoe's body and part of the sole. The segmentation with white pixels isolates the shoe from its background, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Timberland_Womens_Earthkeepers_Classic_Unlined_Boat_Shoe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8013,
+      "qwen_classification": "shoe insole",
+      "qwen_reasoning": "The object has the distinct shape of a shoe insole, with a curved, elongated form that matches the interior contour of a shoe. It features a layered design with a light green top surface, a black middle section, and a red accent on the heel area. The visible structure suggests it is designed to fit inside a shoe, providing cushioning and support. The overall appearance is consistent with a modern athletic or casual shoe insole, possibly with a removable or replaceable design given the visible seams and layered construction."
+    },
+    {
+      "asset_name": "gso_Tory_Burch_Reva_Metal_Logo_Litus_Snake_Print_in_dark_BranchGold",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7878,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object appears to be the toe or front portion of a shoe, likely a boot or hiking boot, given the dark, rugged material and the shape. The visible part shows a rounded toe with a lighter, possibly rubber or synthetic sole material. The texture and coloration suggest it is designed for outdoor or rugged use. The cropped view focuses on the lower front section, which is consistent with a shoe's toe cap and sole area."
+    },
+    {
+      "asset_name": "gso_Timberland_Womens_Waterproof_Nellie_Chukka_Double",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8246,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a single boot, characterized by its high-top design, laces, and thick, rugged sole with deep treads. The material appears to be leather or a similar synthetic, and the color is a distinct orange. The style is typical of work boots or hiking boots, designed for durability and traction. The visible logo on the side (a circular emblem) suggests it is a branded product, likely from a manufacturer like Timberland, which is known for this style. The object is clearly identifiable as footwear, specifically a boot."
+    },
+    {
+      "asset_name": "gso_Toys_R_Us_Treat_Dispenser_Smart_Puzzle_Foobler",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8470,
+      "qwen_classification": "bowling ball",
+      "qwen_reasoning": "The object is a smooth, rounded, blue item with a small dark circular feature on its surface, which appears to be a finger hole. The shape and the presence of the finger hole are characteristic features of a bowling ball. The red accents at the top and bottom are likely decorative or part of the ball's design. The object is clearly segmented from its background, and its form is consistent with a standard bowling ball."
+    },
+    {
+      "asset_name": "gso_Transformers_Age_of_Extinction_Mega_1Step_Bumblebee_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8414,
+      "qwen_classification": "toy car",
+      "qwen_reasoning": "The object appears to be a toy car, specifically a die-cast or plastic model. It has a bright orange body with black wheels and some visible mechanical details, suggesting it might be a remote-controlled or transforming toy. The cropped views show parts of the car's body and wheels, indicating it's a vehicle. The style and color scheme are typical of popular toy car brands like Hot Wheels or similar collectible models."
+    },
+    {
+      "asset_name": "gso_UGG_Jena_Womens_Java_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8462,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a dark brown, leather-like boot with visible stitching, a zipper on the side, and a reinforced toe and heel area. The design suggests it is a sturdy, protective boot, likely for work or outdoor use. The shape and features are consistent with a work boot or a heavy-duty hiking boot."
+    },
+    {
+      "asset_name": "gso_Travel_Smart_Neck_Rest_Inflatable",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8578,
+      "qwen_classification": "brochure",
+      "qwen_reasoning": "The object appears to be a folded brochure or pamphlet. It has a distinct shape with a top section showing a blue sky with clouds and a bottom section that is bright green with text. There is also a white panel on the right side, which may be part of the fold or a design element. The way it is folded and the presence of imagery and text are characteristic of printed promotional or informational materials."
+    },
+    {
+      "asset_name": "gso_Travel_Mate_P_series_Notebook",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8589,
+      "qwen_classification": "laptop",
+      "qwen_reasoning": "The object shown is a portable computer with a hinged design, featuring a screen on one side and a keyboard on the other. The screen is displaying a blue color, and the keyboard is visible with standard keys. This configuration is characteristic of a laptop computer. The object is open and angled, which is a typical way to view a laptop. The white background indicates it has been segmented from its original context, but the object's features are clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Toysmith_Windem_Up_Flippin_Animals_Dog",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8883,
+      "qwen_classification": "plush toy dog",
+      "qwen_reasoning": "The object has a rounded, soft shape with two distinct brown spots on a light-colored surface, resembling the body of a small animal. It has two protrusions that look like ears and a rounded head area. The overall form and features are consistent with a stylized, cartoon-like representation of a puppy or dog, possibly a plush toy or a 3D model. The perspective is from above and slightly to the side, showing the top of the animal's body."
+    },
+    {
+      "asset_name": "gso_Transformers_Age_of_Extinction_Stomp_and_Chomp_Grimlock_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8413,
+      "qwen_classification": "dragon toy",
+      "qwen_reasoning": "The object appears to be a stylized, possibly toy or model, representation of a dragon. It has a long, segmented body with a tail, wings, and a head with horns and an open mouth. The coloration is primarily dark (black or dark gray) with orange or brown accents along the spine and tail. The overall shape and features are consistent with a fantasy dragon, and the segmented appearance suggests it might be a constructed model or toy rather than a living creature."
+    },
+    {
+      "asset_name": "gso_Timberland_Womens_Classic_Amherst_2Eye_Boat_Shoe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8104,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a single shoe, specifically a slip-on style with a rounded toe and a visible sole. The material looks like leather or a similar synthetic material, and the shape suggests it could be a casual or dress shoe. The lighting creates a highlight along the side, indicating a smooth surface. The cropped view focuses on the upper part of the shoe, showing the toe box and a portion of the heel. Based on the visible features, it is most likely a men's or women's casual slip-on shoe, possibly a loafer or moccasin style, though the exact subtype cannot be determined with certainty from this single view."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Stormbuck_Chukka",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8267,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows a close-up view of the heel and side of a shoe. The upper part appears to be made of a tan or light brown suede-like material, and the sole is dark, likely rubber or leather. The shape and construction suggest it is a formal or dress shoe, possibly a loafer or oxford, given the visible stitching and the style of the heel. The perspective is angled from the side and slightly from above, focusing on the heel and the transition from the upper to the sole. There are no clear indicators of athletic use, so it is not a running shoe or sneaker. The object is clearly a footwear item."
+    },
+    {
+      "asset_name": "gso_UGG_Bailey_Button_Womens_Boots_Black_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8523,
+      "qwen_classification": "slipper",
+      "qwen_reasoning": "The object is a dark, soft-looking slipper with a rounded toe and a visible cuff or opening at the back. The texture appears plush or fuzzy, suggesting it is designed for comfort and warmth. The shape is consistent with a house slipper or a cozy indoor shoe, not a formal or outdoor shoe. The object is viewed from a side angle, showing its profile and the opening."
+    },
+    {
+      "asset_name": "gso_UGG_Classic_Tall_Womens_Boots_Grey_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8759,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a single boot, likely a winter or snow boot, characterized by its tall shaft, thick sole, and what appears to be a soft, insulated upper material. The design suggests it is meant for cold weather and provides ankle support. The visible sole has a textured pattern, typical for traction in snow or ice. The overall shape and construction are consistent with a classic winter boot style."
+    },
+    {
+      "asset_name": "gso_Tory_Burch_Kiernan_Riding_Boot",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8692,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object shown is a close-up of a brown, cylindrical item with a smooth, slightly reflective surface. The shape and texture are consistent with a leather or synthetic leather boot, specifically the upper part of a boot or boot shaft. The visible seam or stitching suggests it is a manufactured item, likely footwear. The angle and cropping suggest it is a cropped view of a boot, possibly focusing on the ankle or calf area. Given the limited view, it is most likely a boot, but the specific type (e.g., cowboy boot, hiking boot, etc.) cannot be determined from this perspective."
+    },
+    {
+      "asset_name": "gso_Twinlab_100_Whey_Protein_Fuel_Chocolate",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8336,
+      "qwen_classification": "protein powder container",
+      "qwen_reasoning": "The object is a cylindrical container with a label that includes text and nutritional information, typical of a supplement or protein powder container. The label has a prominent 'TEA' logo, and the container has an orange and black color scheme with a ribbed cap, suggesting it's a fitness or health-related product. The shape, labeling, and cap design are consistent with a shaker bottle or supplement container commonly used for protein shakes or pre-workout formulas."
+    },
+    {
+      "asset_name": "gso_Twinlab_100_Whey_Protein_Fuel_Vanilla",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8511,
+      "qwen_classification": "protein powder container",
+      "qwen_reasoning": "The object is a cylindrical container with a ribbed, orange-colored lid, typical of supplement or protein powder containers. The body is dark, likely black or dark gray, with a label that includes a white rectangular section and orange vertical stripes. The container appears to be partially consumed or damaged, as there is a noticeable bite or tear mark on the lower side. This shape, lid design, and labeling style are characteristic of fitness or health-related product packaging."
+    },
+    {
+      "asset_name": "gso_Twinlab_Nitric_Fuel",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8333,
+      "qwen_classification": "pill bottle",
+      "qwen_reasoning": "The object appears to be a cylindrical container with a label that includes nutritional information (indicated by the text layout and typical formatting of such labels). The cap is orange and appears to be a screw-on type. The shape and labeling suggest it is a supplement or medicine bottle, commonly used for pills or capsules. The label is partially visible and shows text that resembles ingredient lists or serving sizes, which are standard on such products. The overall design is consistent with a typical pill bottle or supplement container."
+    },
+    {
+      "asset_name": "gso_UGG_Classic_Tall_Womens_Boots_Chestnut_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8480,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a brown, soft-looking boot with a rounded toe and a visible seam along the side. The material appears to be suede or a similar textured fabric, and there is a small label or tag visible near the top edge. The shape and construction suggest it is a slip-on style boot, likely designed for casual or winter wear. The cropped view shows only a portion of the boot, but the overall form is consistent with a boot or moccasin-style footwear."
+    },
+    {
+      "asset_name": "gso_Tune_Belt_Sport_Armband_For_Samsung_Galaxy_S3",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8313,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a rectangular cardboard box, likely for a product. It has a yellow side panel with a barcode and text, and a blue and white front panel with some branding or imagery. The visible portion suggests it's a commercial package, possibly for an electronic device, appliance, or consumer product. However, due to the cropped and incomplete view, specific details about the product inside are not discernible. The object is clearly a packaged item, but its exact contents cannot be confidently identified from this fragment."
+    },
+    {
+      "asset_name": "gso_Twinlab_Premium_Creatine_Fuel_Powder",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8555,
+      "qwen_classification": "supplement bottle",
+      "qwen_reasoning": "The object is a bottle with a label that clearly reads \"CREATINE FUEL\" and features the brand name \"THRILLAB\". The bottle has a dark-colored cap and a body that appears to be made of plastic, typical for supplement containers. The label design includes orange and black colors, and the overall shape is consistent with a sports nutrition product bottle. The text \"CREATINE FUEL\" indicates it is a dietary supplement, likely intended to enhance athletic performance."
+    },
+    {
+      "asset_name": "gso_UGG_Bailey_Button_Triplet_Womens_Boots_Black_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8471,
+      "qwen_classification": "tool pouch",
+      "qwen_reasoning": "The object is black and appears to be made of leather or a similar material. It has a curved, somewhat rectangular body with three circular buttons or studs arranged in a row. There is also a curved strap or handle extending from the top right. This combination of features \u2014 a pouch-like body with buttons and a strap \u2014 is characteristic of a traditional leather tool pouch, often used for carrying small tools or implements, such as a knife or scissors. The design is consistent with historical or vintage tool carriers."
+    },
+    {
+      "asset_name": "gso_U_By_Kotex_Cleanwear_Heavy_Flow_Pads_32_Ct",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8666,
+      "qwen_classification": "sanitary pad package",
+      "qwen_reasoning": "The object is a package of feminine hygiene products, specifically sanitary pads. This is evident from the packaging design, which includes a large 'U' logo (commonly associated with the brand 'U by Kotex'), an illustration of a sanitary pad, and text indicating '32 pads' and 'ultra thin'. The color scheme (black, green, pink) and product imagery are typical for this category of consumer goods."
+    },
+    {
+      "asset_name": "gso_Ubisoft_RockSmith_Real_Tone_Cable_Xbox_360",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8285,
+      "qwen_classification": "lanyard",
+      "qwen_reasoning": "The object is a black, flexible, coiled item with a metallic or plastic clip or buckle at one end. The shape and construction suggest it is a strap or lanyard, commonly used to attach items like keys, phones, or badges. The coiled form indicates it is designed to be portable and retractable. The clip at the end is typical for securing the strap to an object or around a neck or wrist."
+    },
+    {
+      "asset_name": "gso_Tory_Burch_Kaitlin_Ballet_Mestico_in_BlackGold",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7898,
+      "qwen_classification": "slipper",
+      "qwen_reasoning": "The object is a dark, elongated, and somewhat oval shape with a smooth, slightly glossy surface. It has a tapered end and a wider, rounded base, resembling the shape of a shoe sole or a slipper. The contours suggest it is designed to fit the human foot, with a curved profile that matches the natural arch and heel of a foot. The lack of visible laces, straps, or other structural elements suggests it is a slip-on style, possibly a ballet flat or a simple slipper. The dark color and smooth texture are consistent with materials like leather or synthetic fabric used in footwear. Given the shape and context, it is most likely a shoe, specifically a slip-on shoe or slipper."
+    },
+    {
+      "asset_name": "gso_TriStar_Products_PPC_Power_Pressure_Cooker_XL_in_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8513,
+      "qwen_classification": "portable compressor",
+      "qwen_reasoning": "The object appears to be a cylindrical device with a metallic, brushed aluminum body and black plastic end caps. It has a label on its side and what looks like mounting brackets or handles on the ends. The shape and construction are consistent with a portable, self-contained unit, possibly for industrial or commercial use. It resembles a small compressor, a vacuum pump, or a portable air compressor. The design suggests it is meant to be mounted or handled, and the label indicates it may be a branded product. Given the lack of specific context, the most likely classification is a portable compressor or air pump."
+    },
+    {
+      "asset_name": "gso_Weisshai_Great_White_Shark",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8417,
+      "qwen_classification": "shark",
+      "qwen_reasoning": "The object in the image has a distinct shape with a pointed snout, visible eyes, and an open mouth showing teeth. These are characteristic features of a shark. The gray coloration and streamlined body shape further support this identification. Although the image is cropped and appears to be a digital rendering or toy, the key anatomical features are consistent with a shark."
+    },
+    {
+      "asset_name": "gso_UGG_Bailey_Bow_Womens_Clogs_Black_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8517,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a dark-colored, likely black, boot or boot-like footwear. It has a thick, sturdy sole and a high shaft that extends up the leg. The design includes decorative lacing or straps with tassels or fringes at the top opening, suggesting a stylistic or fashion-oriented purpose rather than purely utilitarian or athletic use. The material appears to be leather or a similar synthetic fabric. The overall shape and features are consistent with a type of ankle boot or chukka boot, often worn for casual or fashion purposes."
+    },
+    {
+      "asset_name": "gso_UGG_Cambridge_Womens_Black_7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8683,
+      "qwen_classification": "slipper",
+      "qwen_reasoning": "The object is a dark-colored, slip-on style footwear item. It has a rounded toe, a thick sole, and a visible textured or braided trim around the opening. The design and construction suggest it is a type of casual or indoor footwear, possibly a moccasin or slipper, designed for comfort and ease of wear. The material appears to be a soft, flexible fabric or leather-like material. The overall shape and features are consistent with a single shoe, likely the left or right foot, shown from a side angle."
+    },
+    {
+      "asset_name": "gso_Vtech_Roll_Learn_Turtle",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8568,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object is a green, frog-shaped toy with yellow eyes, a yellow mouth, and purple and orange accents. It has a rounded, cartoonish design typical of children's toys, possibly a ride-on toy or a plush toy. The segmented view shows its upper body and head, with visible features like eyes, mouth, and limbs. The style and color scheme suggest it is a playful, child-oriented item."
+    },
+    {
+      "asset_name": "gso_Vans_Cereal_Honey_Nut_Crunch_11_oz_box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8332,
+      "qwen_classification": "cereal box",
+      "qwen_reasoning": "The image shows a rectangular cardboard box with branding and product imagery. The box features a picture of what appears to be honey-flavored cereal pieces, along with text that includes 'Honey Crunch' and a logo that reads 'VIVA'. The design suggests it is a consumer food product, specifically a box of cereal. The packaging style, including the barcode on the side and the product name, is typical for retail cereal boxes."
+    },
+    {
+      "asset_name": "gso_US_Army_Stash_Lunch_Bag",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8509,
+      "qwen_classification": "lunch bag",
+      "qwen_reasoning": "The object appears to be a rectangular, soft-sided bag with a flap closure on top. The material has a textured, possibly waterproof or durable fabric appearance with a brownish, mottled pattern. The shape and construction suggest it is designed to hold items, likely for carrying food or personal belongings. This is consistent with the appearance of a lunch bag or a small insulated food carrier. The flap closure is typical for such bags to keep contents secure. The overall design is utilitarian and common for everyday use."
+    },
+    {
+      "asset_name": "gso_Twinlab_100_Whey_Protein_Fuel_Cookies_and_Cream",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8490,
+      "qwen_classification": "protein powder container",
+      "qwen_reasoning": "The object is a cylindrical container with a label that includes text and branding. The visible text on the label reads \"WHEY FUEL\" and \"NUTRITION\". The design, including the orange and black color scheme and the shape, is typical of a protein powder or nutritional supplement container. The container has a screw-on lid and appears to be made of plastic, consistent with packaging for dietary supplements. The label also shows a nutritional facts panel, which is common on such products. Based on these visual cues, this is clearly a container for a dietary supplement, specifically a whey protein powder."
+    },
+    {
+      "asset_name": "gso_Vtech_Stack_Sing_Rings_636_Months",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8281,
+      "qwen_classification": "toy",
+      "qwen_reasoning": "The object is a colorful, segmented toy with multiple rings stacked together, each a different color (blue, red, orange, yellow, green, purple). The shape and arrangement are characteristic of a classic baby rattle or stacking ring toy, often used for sensory development and motor skills. The blue end appears to have a logo or design, which is common on commercial toys. The object is clearly identifiable as a toy based on its appearance and context."
+    },
+    {
+      "asset_name": "gso_Weston_No_22_Cajun_Jerky_Tonic_12_fl_oz_nLj64ZnGwDh",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8188,
+      "qwen_classification": "sauce bottle",
+      "qwen_reasoning": "The object is a dark brown bottle with a black cap and a yellow label. The shape and labeling suggest it is a commercial food product, likely a condiment such as soy sauce, barbecue sauce, or a similar liquid seasoning. The label has text and possibly an image, which is typical for packaged food items. The bottle's design is consistent with common sauce bottles found in grocery stores."
+    },
+    {
+      "asset_name": "gso_Whey_Protein_Vanilla_12_Packets",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8806,
+      "qwen_classification": "protein powder container",
+      "qwen_reasoning": "The object is a rectangular package with printed text and branding. The visible text includes \"WHEY PROTEIN\" and \"100% Natural\", indicating it is a nutritional supplement product. The design features a blue and green color scheme with a product image on the front. This is consistent with packaging for whey protein powder, a common fitness and dietary supplement."
+    },
+    {
+      "asset_name": "gso_VANS_FIRE_ROASTED_VEGGIE_CRACKERS_GLUTEN_FREE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8462,
+      "qwen_classification": "printed material",
+      "qwen_reasoning": "The image shows a close-up of a printed document, likely a product package or informational leaflet. It has text, a logo (a red square with white text), and a sunflower graphic at the bottom. The text includes phrases like \"Sugar Free\" and \"The Sweet That Loves You Back,\" suggesting it's for a food or beverage product. The layout and design are typical of consumer packaging or promotional material. The object is clearly a printed item, not a physical product like a bottle or container."
+    },
+    {
+      "asset_name": "gso_Utana_5_Porcelain_Ramekin_Large",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8647,
+      "qwen_classification": "ramekin",
+      "qwen_reasoning": "The object is a small, round, deep container with a smooth, slightly reflective interior and a darker exterior. Its shape and material suggest it is made of ceramic or a similar material, commonly used for serving or cooking. The rim is slightly raised, and the overall form is consistent with a ramekin or small bowl. There are no handles or other features that would identify it as a different type of container. The object appears empty and is presented in isolation, which is typical for product or inventory images."
+    },
+    {
+      "asset_name": "gso_Wilton_Easy_Layers_Cake_Pan_Set",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8718,
+      "qwen_classification": "craft supply box",
+      "qwen_reasoning": "The object is a product box, likely for a set of colored items. The visible text \"Easy Layers\" and the rainbow-colored strips suggest it's packaging for a craft or art supply, such as colored paper, cardstock, or adhesive sheets. The cutout in the box indicates it's designed to display the contents. The purple logo and branding further support it being commercial packaging."
+    },
+    {
+      "asset_name": "gso_Unmellow_Yellow_Tieks_Neon_Patent_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8261,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The image shows the bottom sole of a shoe, viewed from directly underneath. It has a distinct shape with a curved heel and forefoot, typical of footwear. The sole is multi-colored: a light blue or teal central area, a brownish section near the heel, and a bright yellow outer edge. The presence of a brand name or logo (partially visible as 'SHO') on the heel area further confirms it is a shoe. The segmented view isolates the sole, which is the primary functional and identifying part of the shoe."
+    },
+    {
+      "asset_name": "gso_Wilton_Pearlized_Sugar_Sprinkles_525_oz_Gold",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8287,
+      "qwen_classification": "spice shaker",
+      "qwen_reasoning": "The object is a cylindrical container with a white cap and a label. The label has text and a logo, which is typical for food or spice containers. The body of the container appears to be filled with a granular or powdered substance, consistent with a spice or seasoning shaker. The shape and design strongly suggest it is a spice shaker bottle, commonly used in kitchens for dispensing spices."
+    },
+    {
+      "asset_name": "gso_U_By_Kotex_Sleek_Regular_Unscented_Tampons_36_Ct_Box",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8782,
+      "qwen_classification": "feminine hygiene product package",
+      "qwen_reasoning": "The object is a black rectangular package with text and graphics. It features a large stylized 'U' logo, the word 'steek' underneath it, and a pink circle with the number '36' in the top left corner. There is also a yellow banner with the word 'TRANSPARENT' and a small circular seal in the top right. The design and text suggest it is a product package, likely for feminine hygiene products, given the branding and the number '36' which commonly indicates the count of items inside. The overall appearance is consistent with a commercial product box."
+    },
+    {
+      "asset_name": "gso_Winning_Moves_1180_Aggravation_Board_Game",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8216,
+      "qwen_classification": "board game box",
+      "qwen_reasoning": "The object is a rectangular box with colorful graphics and text. The prominent text on the box reads \"Addiction\" in a stylized font, and there are illustrations of what appear to be game pieces or cards. The overall design and presentation suggest it is packaging for a board game or a similar tabletop game. The box has a glossy finish and is angled, showing its three-dimensional form."
+    },
+    {
+      "asset_name": "gso_Womens_Betty_Chukka_Boot_in_Grey_Jersey_Sequin",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8394,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object appears to be a white athletic shoe, likely a sneaker. Key features include the visible lacing system, the shape of the upper, and the presence of a blue accent on the heel or sole area. The design is consistent with casual or athletic footwear. The cropped view shows only a portion of the shoe, but the identifiable elements strongly suggest it is a shoe."
+    },
+    {
+      "asset_name": "gso_Weston_No_33_Signature_Sausage_Tonic_12_fl_oz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8174,
+      "qwen_classification": "sauce bottle",
+      "qwen_reasoning": "The object is a bottle with a label that clearly reads \"SAUSAGE SAUCE\". The bottle has a dark-colored liquid inside, consistent with a condiment or sauce. The shape and labeling indicate it is a commercial food product, specifically a bottle of sausage sauce. The label also features a logo with a stylized 'W', which may indicate a brand. The bottle appears to be made of glass or plastic, with a typical sauce bottle design."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Brown_Deerskin_JJ2pfEHTZG7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8220,
+      "qwen_classification": "boat shoe",
+      "qwen_reasoning": "The object is a dark-colored boat shoe, characterized by its low-profile design, flat sole, and distinctive lacing system with eyelets. The visible stitching along the edges and the light-colored sole are typical features of this type of footwear. The overall shape and construction suggest it is designed for casual wear, often associated with nautical or maritime styles."
+    },
+    {
+      "asset_name": "gso_Whey_Protein_Chocolate_12_Packets",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8874,
+      "qwen_classification": "protein powder box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with visible text and graphics. The prominent text \"WHEY PROTEIN\" and \"12 PACKETS\" indicates it is packaging for a dietary supplement. The design includes nutritional information panels and barcodes, typical of consumer product packaging. The color scheme (orange, yellow, and dark brown) and layout are consistent with commercial protein powder packaging. The object is clearly identifiable as a product box for whey protein powder."
+    },
+    {
+      "asset_name": "gso_Victor_Reversible_Bookend",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8951,
+      "qwen_classification": "buckle",
+      "qwen_reasoning": "The object appears to be a metallic, rectangular component with a hinge-like structure in the middle, suggesting it is designed to fold or open. The surface has a brushed or matte finish, and the edges are slightly rounded. This design is characteristic of a buckle, particularly a type used in belts or straps, where the two halves can be opened and closed. The central seam and the way the two parts are connected indicate a functional mechanism for fastening or securing something. It does not resemble a book, a tool, or any other common object based on its shape and structure."
+    },
+    {
+      "asset_name": "gso_Whey_Protein_3_Flavor_Variety_Pack_12_Packets",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8929,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with printed text and a barcode visible on its side. The box has a blue main surface with a brown top and a green side visible. The presence of printed information, including what appears to be a barcode and text (likely product details or instructions), is characteristic of commercial packaging. The shape and material are consistent with a standard shipping or retail box for consumer goods. The perspective shows three sides of the box, confirming its three-dimensional, box-like structure."
+    },
+    {
+      "asset_name": "gso_W_Lou_z0dkC78niiZ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8715,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object shown is a single boot, viewed from a side angle. It has a distinct heel, a curved sole, and an upper part made of what appears to be leather or a similar material in a brown color. The shape and construction are characteristic of footwear designed for the foot and lower leg, specifically a boot. The cropped view focuses only on one boot, not a pair, and the white background indicates it has been segmented from its original context. There are no clear indicators of specific use (e.g., hiking, work, dress) from this view alone, but it is clearly a boot."
+    },
+    {
+      "asset_name": "gso_Wilton_PreCut_Parchment_Sheets_10_x_15_24_sheets",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7957,
+      "qwen_classification": "product packaging",
+      "qwen_reasoning": "The object appears to be a rectangular package or box, likely for a product. It has printed text and images on its surface. The text includes \"feuille de papier\" (French for \"paper leaf\" or \"paper sheet\"), which suggests it might be packaging for paper products, possibly decorative or craft paper. The images on the package show various colored paper cutouts or shapes, reinforcing the idea that it contains paper items. The overall shape and presentation are consistent with commercial product packaging."
+    },
+    {
+      "asset_name": "gso_Womens_Angelfish_Boat_Shoe_in_Linen_Oat",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7888,
+      "qwen_classification": "boat",
+      "qwen_reasoning": "The object appears to be a green, elongated item with a curved shape, resembling a boat or a small watercraft. It has a distinct bow at the front and a stern at the back, with what looks like a small cabin or seating area. The coloration is primarily green with some darker and lighter shading, suggesting it might be a toy or a model. The overall form and features are consistent with a small boat, possibly a rowboat or a toy boat."
+    },
+    {
+      "asset_name": "gso_Ultra_JarroDophilus",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8650,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a brightly colored, rectangular box with text and graphics on its surface. The visible text includes \"Ultra Jorro-Dophilus\" and \"10\" with a small \"10\" symbol, suggesting it is a product package. The design, with its bold colors and product name, is characteristic of a commercial product, likely a dietary supplement or probiotic given the name \"Dophilus\" (a common term for probiotics). The box appears to be made of cardboard or similar packaging material, and the perspective suggests it is a three-dimensional object. The white background is masking the surrounding environment, focusing attention on the product packaging."
+    },
+    {
+      "asset_name": "gso_Womens_Betty_Chukka_Boot_in_Salt_Washed_Red_AL2YrOt9CRy",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 7999,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up of a pink sneaker or athletic shoe. Key features include a white rubber sole with a blue stripe, pink upper material, yellow laces threaded through metal eyelets, and a visible brand logo on the side. The construction and design are typical of casual or athletic footwear. The cropped view focuses on the side and top portion of the shoe, excluding the toe and heel, but the identifiable elements strongly suggest it is a shoe."
+    },
+    {
+      "asset_name": "gso_White_Rose_Tieks_Leather_Ballet_Flats_with_Floral_Rosettes",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 7920,
+      "qwen_classification": "sandal",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sandal or slip-on style. It has a visible sole with a turquoise-colored insole or footbed, and a white, fluffy or textured upper material that looks like it could be faux fur or a similar soft fabric. The design suggests it is meant for casual or decorative use, possibly for indoor or warm weather. The cropped view shows the side and bottom of the shoe, but not enough to identify a specific brand or model. However, the overall structure and materials are consistent with a type of casual footwear."
+    },
+    {
+      "asset_name": "gso_Wishbone_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8548,
+      "qwen_classification": "cosmetic bag",
+      "qwen_reasoning": "The object is a cylindrical item with a patterned surface. The pattern consists of interlocking diamond or lattice shapes in purple and white. The shape and pattern suggest it is a decorative or functional cylindrical container, possibly a cosmetic bag, a small storage pouch, or a rolled-up item like a mat or towel. The presence of a small zipper pull at the bottom indicates it is a zippered pouch. Given the context and appearance, it is most likely a cosmetic or toiletry bag, often used for travel or organizing small items."
+    },
+    {
+      "asset_name": "gso_Wild_Copper_Tieks_Metallic_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 7948,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, specifically a flat, slip-on style with a pointed toe. It has a textured, possibly snakeskin-patterned upper in a tan or light brown color. The sole is a contrasting teal or green color. The shoe appears to be a women's ballet flat or a similar casual flat shoe. The white areas are likely part of the shoe's design (e.g., a strap or insole) or artifacts from the segmentation process, but they are part of the object being shown. The overall shape and features are consistent with a women's flat shoe."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Linen_Natural_Sparkle_Suede_kqi81aojcOR",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8218,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object shown is a shoe, specifically a sneaker. It has a thick, cushioned sole with a light beige or cream color. The upper part of the shoe appears to be made of a light-colored material, possibly canvas or suede, with visible stitching and a strap or lace detail. The overall design suggests a casual or lifestyle sneaker. The angle of the image shows the side and bottom of the shoe, highlighting its profile and sole structure."
+    },
+    {
+      "asset_name": "gso_Womens_Betty_Chukka_Boot_in_Navy_aEE8OqvMII4",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8201,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object has a distinct curved, elongated shape with a rounded toe and heel, characteristic of footwear. The visible stitching and the overall form suggest it is a shoe, likely a sneaker or athletic shoe, given its design and the presence of what appears to be a zipper or closure mechanism on the side. The dark blue color and textured surface are consistent with common shoe materials. The object is viewed from an angled perspective, showing the side and top portion, which is typical for displaying footwear."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Linen_Natural_Sparkle_Suede_w34KNQ41csH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8131,
+      "qwen_classification": "boat shoe",
+      "qwen_reasoning": "The object is a single shoe, specifically a boat shoe or deck shoe, characterized by its slip-on design, flat sole, and lacing system with eyelets. It has a light tan or beige upper, a darker sole, and a visible interior lining. The style is typical of casual or nautical footwear. The white background indicates it has been cropped and segmented from its original context, but the object's features are clearly identifiable."
+    },
+    {
+      "asset_name": "gso_Womens_Canvas_Bahama_in_Black",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8314,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. It has a curved, rounded sole typical of modern footwear, and the visible side shows a dark upper material with a lighter-colored sole. The shape and design suggest it is designed for casual or athletic use. The white background is masking the surrounding environment, but the object's form is clearly identifiable as a shoe."
+    },
+    {
+      "asset_name": "gso_Womens_Betty_Chukka_Boot_in_Navy_Jersey_Sequin_y0SsHk7dKUX",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8218,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a top-down perspective. It has a dark blue or black upper, light-colored laces (possibly white or cream), and a rounded toe. The construction appears to be a casual or dress shoe, possibly a loafer or boat shoe, given the lack of visible lacing structure and the smooth, stitched appearance of the upper. The white background indicates it has been cropped and segmented from its original context, but the object's form is clearly identifiable as a shoe."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Linen_Oat_IbrSyJdpT3h",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 7881,
+      "qwen_classification": "baseball glove",
+      "qwen_reasoning": "The object appears to be a baseball glove, specifically a catcher's mitt, based on its shape, the visible stitching, and the brand name \"SPERRY\" printed on the side. The design includes a large pocket area typical of catcher's gloves, and the overall structure suggests it is made of leather or a similar material. The partial view shows the top and side of the glove, which is consistent with how such gloves are often photographed or displayed."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Linen_Oat_niKJKeWsmxY",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8106,
+      "qwen_classification": "boat shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a top-down perspective. It has a classic boat shoe design with visible laces and a rounded toe. The material appears to be leather or a similar synthetic material, and the color is brown. The interior of the shoe is visible, showing the insole and heel area. The shape and features are consistent with a casual, comfortable shoe style often worn for everyday use or nautical activities."
+    },
+    {
+      "asset_name": "gso_Womens_Audrey_Slip_On_Boat_Shoe_in_Graphite_Nubuck_xWVkCJ5vxZe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8022,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a dark blue, elongated item with a curved, streamlined shape. There are two white, bone-like or skeletal markings on its side, which are likely decorative or part of its design. The overall form suggests it is a piece of footwear, specifically a shoe, given its shape and the presence of what could be a sole or heel area. The design is somewhat abstract or stylized, but the silhouette is consistent with a shoe, possibly a sneaker or athletic shoe. The white markings could be part of the branding or design motif."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Brown_Deerskin_i1TgjjO0AKY",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8326,
+      "qwen_classification": "gaming controller",
+      "qwen_reasoning": "The object appears to be a handheld electronic device, likely a gaming controller or a similar input device. It has a distinct ergonomic shape with a curved body, and visible button-like features on the lower portion. The top surface has a textured or patterned area, possibly for grip or aesthetic design. The overall form factor and button layout are consistent with a video game controller, though the specific brand or model cannot be identified from this view. The object is segmented from its background, and the white areas are not part of the object."
+    },
+    {
+      "asset_name": "gso_Womens_Hikerfish_Boot_in_Linen_Leather_Sparkle_Suede_imlP8VkwqIH",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8529,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a single, yellow boot with visible laces and a sturdy sole. The design suggests it is a casual or work-style boot, possibly for outdoor or everyday use. The shape, including the ankle support and lacing system, is characteristic of a boot rather than a slip-on shoe or other footwear. The color is uniform and appears to be a solid yellow, which may be for visibility or style."
+    },
+    {
+      "asset_name": "gso_Womens_Angelfish_Boat_Shoe_in_Linen_Leopard_Sequin_NJDwosWNeZz",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8079,
+      "qwen_classification": "hair clip",
+      "qwen_reasoning": "The object is a golden-colored, curved item with a decorative pattern along its length and a small loop or clasp at one end. Its shape and features suggest it is a type of accessory, possibly a decorative hair clip or a small purse/clutch. The curved form and the presence of a clasp or loop are consistent with hair clips designed to hold hair in place, often used for styling. The golden color and ornate pattern suggest it is decorative, likely intended for fashion or aesthetic purposes. It does not resemble footwear, a bottle, or a phone. The most plausible classification is a hair clip, specifically a decorative or ornamental one."
+    },
+    {
+      "asset_name": "gso_Womens_Canvas_Bahama_in_White_UfZPHGQpvz0",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8070,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a side view of a shoe, specifically showing the heel and midsole area. The shape suggests it is a casual or athletic shoe, with visible stitching or seam lines along the side. The material looks like synthetic leather or rubber, common in modern footwear. The curved silhouette and the presence of a heel counter are characteristic features of a shoe. The object is cropped and isolated, but its form is unmistakably that of footwear."
+    },
+    {
+      "asset_name": "gso_Womens_Hikerfish_Boot_in_Black_Leopard_ridcCWsv8rW",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8531,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a footwear item with a distinct design. It features a leopard print pattern on the upper section, a black sole, and visible lacing. The shape, including the heel and toe, is consistent with a boot or ankle boot style. The presence of laces and the overall structure indicate it is designed for wearing on the foot, specifically covering the ankle area. The material appears to be fabric or synthetic leather, common for casual or fashion boots."
+    },
+    {
+      "asset_name": "gso_Womens_Multi_13",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8567,
+      "qwen_classification": "pill bottle",
+      "qwen_reasoning": "The object appears to be a cylindrical container with a white plastic body and a white cap. There is a label wrapped around the middle with red and orange stripes. The shape and labeling suggest it is a container for pills or supplements, commonly known as a pill bottle. The cap is slightly off-center, indicating it may have been recently opened or is in the process of being opened. The overall design is typical of pharmaceutical packaging."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Linen_Oat",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8465,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a close-up of a dark-colored shoe, likely black or dark navy, with white laces. The visible portion includes the toe, part of the upper, and the lacing system. The shape and construction suggest it is a casual or dress shoe, possibly a loafer or oxford style, given the flat sole and lacing pattern. The material appears to be leather or a similar synthetic fabric. The cropped view focuses on the front and side of the shoe, but enough detail is visible to confidently classify it as a shoe."
+    },
+    {
+      "asset_name": "gso_Womens_Canvas_Bahama_in_White_4UyOhP6rYGO",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8138,
+      "qwen_classification": "insole",
+      "qwen_reasoning": "The object appears to be a white, curved, elongated item with a small blue label or tag on its surface. The shape and context suggest it is likely a shoe insole or a similar footbed component. The curved form matches the typical contour of a foot, and the presence of a label indicates it is a manufactured product, possibly for footwear. The white color and smooth texture are consistent with materials used in insoles (e.g., foam or gel)."
+    },
+    {
+      "asset_name": "gso_Womens_Suede_Bahama_in_Graphite_Suede_p1KUwoWbw7R",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7825,
+      "qwen_classification": "flip-flop",
+      "qwen_reasoning": "The object shown is a flip-flop sandal. It has a gray sole and a yellow strap that goes between the toes. The design is typical of casual footwear, often worn for comfort and ease of use. The visible branding on the sole suggests it is a manufactured product. The perspective is a top-down view focusing on the footbed and strap area."
+    },
+    {
+      "asset_name": "gso_Womens_Hikerfish_Boot_in_Linen_Leather_Sparkle_Suede_QktIyAkonrU",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8652,
+      "qwen_classification": "boot",
+      "qwen_reasoning": "The object is a single boot, viewed from an angled perspective. It has visible laces, a lace-up closure system, and a sturdy, elevated sole. The material appears to be leather or a similar synthetic material, and the style suggests it is a casual or work boot, possibly a hiking or ankle boot. The design includes a reinforced toe area and a padded collar, which are common features in this type of footwear. The object is clearly identifiable as footwear, specifically a boot, and there are no ambiguous features."
+    },
+    {
+      "asset_name": "gso_Womens_Suede_Bahama_in_Graphite_Suede_t22AJSRjBOX",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 7997,
+      "qwen_classification": "boat shoe",
+      "qwen_reasoning": "The object is a dark-colored, low-profile shoe with laces and a visible sole. It has a classic boat shoe design, characterized by its flat sole, rounded toe, and lacing system. The interior lining appears to have a patterned fabric, which is common in this style of footwear. The overall shape and features strongly suggest it is a boat shoe, often worn for casual or nautical purposes."
+    },
+    {
+      "asset_name": "gso_Womens_Sparkle_Suede_Angelfish_in_Grey_Sparkle_Suede_Silver",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8196,
+      "qwen_classification": "shoe sole",
+      "qwen_reasoning": "The object is a dark blue, oval-shaped item with a textured surface and a series of embossed rectangular patterns along its lower edge. The texture and shape are consistent with the sole of a shoe, specifically the insole or outsole. The embossed patterns are typical for providing grip or structural reinforcement in footwear. The object appears to be a segment of a shoe sole, likely from a casual or athletic shoe, given the design and material appearance."
+    },
+    {
+      "asset_name": "gso_Womens_Sequin_Bahama_in_White_Sequin_yGVsSA4tOwJ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 7978,
+      "qwen_classification": "sleep mask",
+      "qwen_reasoning": "The object is a light blue, curved, padded item with a small black rectangular label or tag on its surface. Its shape and material suggest it is designed to be worn on the head or face. The most likely use is for blocking out light, which is characteristic of sleep masks or eye masks. The padded, contoured design is typical for comfort during sleep or rest. The label may indicate the brand or product information, which is common on such items."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_White_Tumbled_YG44xIePRHw",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8090,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a shoe, specifically a sneaker or athletic shoe. It has a distinct sole with visible tread patterns and a curved upper section that suggests a typical shoe shape. The color scheme is a combination of brown and gray, which is common for casual or athletic footwear. The segmented view shows the side profile, including the midsole and outsole, which are characteristic features of a shoe. The object is clearly not a shoe sole alone, as the upper part is also visible, and it does not resemble other common objects like a water bottle, phone, or tool."
+    },
+    {
+      "asset_name": "gso_adiZero_Slide_2_SC",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8064,
+      "qwen_classification": "slide sandal",
+      "qwen_reasoning": "The object is a single slip-on sandal with a yellow sole and white straps. The straps feature three parallel stripes, which is a signature design element of the Adidas brand. The sole has the Adidas logo embossed on it, further confirming the brand. The style is a slide sandal, commonly worn for casual or beach use. The object is clearly identifiable as footwear."
+    },
+    {
+      "asset_name": "gso_ZX700_mzGbdP3u6JB",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8037,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object shown is a dark-colored shoe with a distinct curved shape and a visible sole. The front part of the shoe features a colorful stripe pattern with orange, yellow, and red hues. The overall silhouette and design are consistent with a casual or athletic shoe, possibly a slip-on style. The segmented view focuses only on the shoe, with the white background removed, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Womens_Suede_Bahama_in_Graphite_Suede_cUAjIMhWSO9",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8154,
+      "qwen_classification": "boat shoe",
+      "qwen_reasoning": "The object is a single shoe, viewed from a side angle. It has a classic boat shoe design, characterized by its low profile, flat sole, and visible laces. The upper appears to be made of a light-colored material, possibly canvas or leather, with a plaid or tartan pattern visible on the interior lining and possibly the tongue. The stitching and overall construction are consistent with casual, nautical-style footwear. The white background indicates it has been cropped and segmented from its original context."
+    },
+    {
+      "asset_name": "gso_Womens_Hikerfish_Boot_in_Black_Leopard_bVSNY1Le1sm",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8370,
+      "qwen_classification": "handbag",
+      "qwen_reasoning": "The object appears to be a bag or purse, characterized by its curved shape and the presence of a strap with a leopard print pattern. The main body is a solid dark blue color, and there is a visible red or maroon interior lining. The strap is wide and features a classic leopard print design with black and tan spots on a light background. The way the strap is attached and the overall structure suggest it is a handbag or shoulder bag. The cropped view focuses on the upper portion, including the strap and part of the body, but the overall form is consistent with a common type of bag."
+    },
+    {
+      "asset_name": "gso_Womens_Sequin_Bahama_in_White_Sequin_V9K1hf24Oxe",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8020,
+      "qwen_classification": "slip-on shoe",
+      "qwen_reasoning": "The object is a light tan or beige slip-on shoe with a visible seam along the side and a strap or lace detail near the top. The shape, including the rounded toe and the way the upper part curves around the foot, is characteristic of a casual slip-on shoe, possibly a loafer or moccasin style. The lack of visible laces or buckles suggests it's designed for easy wear, consistent with slip-on footwear. The material appears to be leather or a similar synthetic material, common for this type of shoe."
+    },
+    {
+      "asset_name": "gso_ZX700_lYiwcTIekXk",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8550,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object shown is a shoe, specifically a sneaker. It has a distinct sole, upper material, and visible lacing or strap areas. The design includes color blocks (white, teal, red, black), which is common in athletic or casual sneakers. The shape and structure are consistent with footwear designed for walking or running. The cropped view focuses on the side and heel area, but the overall form is unmistakably that of a shoe."
+    },
+    {
+      "asset_name": "gso_adizero_5Tool_25",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8187,
+      "qwen_classification": "athletic shoe",
+      "qwen_reasoning": "The object is a dark-colored athletic shoe with a high-top design. It features three distinct white stripes running vertically along the side, which is a signature design element of Adidas footwear. The shoe has a lace-up closure system and a visible sole with a textured pattern, typical of athletic or training shoes. The overall shape and design suggest it is intended for sports or physical activity."
+    },
+    {
+      "asset_name": "gso_Womens_Teva_Capistrano_Bootie_ldjRT9yZ5Ht",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8336,
+      "qwen_classification": "ankle boot",
+      "qwen_reasoning": "The object is a single boot, specifically an ankle boot. It has a dark green or olive color, a rounded toe, and a low heel. The upper part appears to be made of leather or a similar material and features a folded or ruched design around the ankle area. The boot is cropped and isolated against a white background, which is consistent with the provided context. Based on its shape, material, and style, it is clearly identifiable as a type of footwear."
+    },
+    {
+      "asset_name": "gso_Wooden_ABC_123_Blocks_50_pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8687,
+      "qwen_classification": "stacked cardboard boxes",
+      "qwen_reasoning": "The object appears to be a stack of cardboard boxes, likely shipping or storage containers. The visible surfaces show various labels, barcodes, and markings typical of commercial packaging. The boxes are stacked in a somewhat irregular, staggered manner, suggesting they might be in transit or stored. The texture and color are consistent with corrugated cardboard, and the presence of printed labels confirms their function as packaged goods. The perspective is a three-dimensional view, showing multiple sides of the stack."
+    },
+    {
+      "asset_name": "gso_ZigKick_Hoops",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8475,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a shoe, specifically a sneaker. It has a white and blue color scheme with a distinctive wavy, textured pattern along the top edge. The visible lacing system and overall shape are characteristic of athletic footwear. The brand name 'Hoka' is visible on the side, which is a known manufacturer of running shoes. The design suggests it is intended for running or other athletic activities, likely a lightweight, cushioned model."
+    },
+    {
+      "asset_name": "gso_Womens_Teva_Capistrano_Bootie",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8167,
+      "qwen_classification": "sock",
+      "qwen_reasoning": "The object appears to be a single sock, likely a sock for the foot, based on its shape, texture, and the way it is folded or bunched. The visible portion shows a ribbed or textured pattern on one side, which is common in socks for grip or comfort. The color is a light purple or lavender. The object is not a shoe, glove, or any other type of footwear or apparel. The segmented view isolates the sock from its surroundings, confirming it is the target object."
+    },
+    {
+      "asset_name": "gso_YumYum_D3_Liquid",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8388,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with an orange color scheme. On the top surface, there is an image of a small bottle with a dropper, suggesting it contains a liquid product. The box also has text and a barcode, which are typical features of commercial packaging. The overall design and labeling indicate it is a product package, likely for a consumable item such as a supplement, essential oil, or similar liquid product. The perspective is a side view showing the top and one side of the box."
+    },
+    {
+      "asset_name": "gso_Womens_Sparkle_Suede_Bahama_in_Silver_Sparkle_Suede_Grey_Patent_tYrIBLMhSTN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8208,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object is a dark-colored, low-profile shoe with a rounded toe and visible lacing system. The design appears to be a casual or dress shoe, possibly a loafer or oxford style, given the presence of laces and the overall silhouette. The material looks like leather or a similar synthetic fabric, and the shoe is shown from a side angle, highlighting its profile and construction details. There are no clear indicators of athletic use, such as rubber soles or reinforced stitching typical of running shoes. The object is clearly a footwear item, and the visual evidence supports a confident classification."
+    },
+    {
+      "asset_name": "gso_ZX700_mf9Pc06uL06",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8371,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from an angled perspective. Key features include: white laces, a white rubber sole, a maroon upper with yellow and white accents, and a blue tongue with a white trefoil logo (the iconic Adidas logo). The design, including the three stripes on the side and the overall silhouette, is characteristic of a classic Adidas sneaker, likely from the 1980s or 1990s. The object is clearly identifiable as footwear, specifically a sneaker."
+    },
+    {
+      "asset_name": "gso_adizero_F50_TRX_FG_LEA",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8133,
+      "qwen_classification": "cleat",
+      "qwen_reasoning": "The object is a single athletic shoe, likely a soccer or football cleat, based on its shape, low profile, and the visible studs on the sole. The shoe appears worn and dirty, with a light gray or white upper and some red accents near the heel and toe. The design suggests it is meant for sports on grass or turf, with a snug fit and minimal lacing, typical of cleats. The white background indicates it has been cropped and segmented from its original context."
+    },
+    {
+      "asset_name": "gso_Womens_Sparkle_Suede_Bahama_in_Silver_Sparkle_Suede_Grey_Patent_x9rclU7EJXx",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8156,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a white, curved item with a smooth, slightly textured surface. It has a distinct shape with a rounded top and a flat bottom, and a small rectangular label or marking on the side. The overall form and proportions suggest it is a type of footwear, specifically a shoe. The angle of the view shows the side and bottom of the object, which is consistent with how shoes are often photographed or displayed. The lack of visible laces, soles, or other specific features makes it difficult to identify the exact type of shoe (e.g., sneaker, sandal, boot), but the general silhouette strongly indicates it is a shoe."
+    },
+    {
+      "asset_name": "gso_adistar_boost_m",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8217,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object shown is a close-up view of a shoe, specifically focusing on the sole and midsole area. Key features include a black rubber outsole with a distinct tread pattern, a white midsole with visible structural lines, and a bright lime green accent on the heel and side. The design and materials are consistent with athletic footwear, particularly running shoes, which often feature such patterns for traction and cushioning. The segmented, cropped nature of the image isolates the shoe from its surroundings, confirming it is the primary subject."
+    },
+    {
+      "asset_name": "gso_Wrigley_Orbit_Mint_Variety_18_Count",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8438,
+      "qwen_classification": "candy box",
+      "qwen_reasoning": "The object is a rectangular cardboard box with branding and text visible. The prominent logo \"Rbit\" (likely a stylized version of \"Rbit\" or \"Rbit\") is displayed on the side. The box has a light blue color scheme with some green accents. There are nutritional facts and other text printed on the side, indicating it is a consumer product package. The shape and labeling suggest it is a box of individually wrapped items, such as candy or snacks. The \"Rbit\" branding is associated with a well-known brand of candy (Rbit, which is a brand of candy bars, particularly popular in some regions). The box appears to be a multi-pack or case of these candy bars."
+    },
+    {
+      "asset_name": "gso_BREAKFAST_MENU",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8305,
+      "qwen_classification": "cutting board",
+      "qwen_reasoning": "The object is a white, rectangular cutting board with a handle cutout at the top. It has a slightly textured surface and a small, indistinct mark or logo near the center. The shape and features are consistent with a kitchen cutting board used for chopping food."
+    },
+    {
+      "asset_name": "gso_Grand_Prix",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8132,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a blue athletic shoe with white stripes on the side, a white sole, and a red accent on the heel. The design, including the three stripes and the logo on the heel, is characteristic of Adidas sneakers. The style appears to be a casual or low-top sneaker, suitable for everyday wear or light athletic activities."
+    },
+    {
+      "asset_name": "gso_Lovable_Huggable_Cuddly_Boutique_Teddy_Bear_Beige",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8262,
+      "qwen_classification": "teddy bear",
+      "qwen_reasoning": "The object is a plush, stuffed toy with a soft, fuzzy texture. It has the distinct shape of a bear, with visible limbs, a rounded body, and a head with a single visible eye. The color is a light brown or tan, typical of many teddy bears. The overall appearance is that of a classic children's comfort toy."
+    },
+    {
+      "asset_name": "gso_3M_Antislip_Surfacing_Light_Duty_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8353,
+      "qwen_classification": "tape roll",
+      "qwen_reasoning": "The object is a roll of white tape, likely adhesive tape, given its cylindrical shape with a central core and the way the material is wound. The smooth, uniform white surface and the visible inner cardboard core are characteristic of common household or industrial tape rolls. The object is presented in a cropped view, focusing only on the tape roll itself, which is consistent with the provided context."
+    },
+    {
+      "asset_name": "gso_JA_Henckels_International_Premio_Cutlery_Block_Set_14Piece",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8533,
+      "qwen_classification": "knife block",
+      "qwen_reasoning": "The object shown is a wooden knife block with several knives inserted into it. The block is light-colored wood with a visible grain, and the knives have black handles and are partially visible, protruding from the block. This is a common kitchen storage item designed to hold and organize knives."
+    },
+    {
+      "asset_name": "gso_Big_Dot_Aqua_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8369,
+      "qwen_classification": "cosmetic bag (uncertain)",
+      "qwen_reasoning": "The object is a cylindrical container with a zipper closure and a pull tab, featuring a pattern of large green circles on a purple background. This shape, closure mechanism, and pattern are characteristic of a cosmetic bag or a pencil case designed to hold small personal items. The zipper suggests it is meant to be opened and closed repeatedly, and the compact, cylindrical form is typical for portable storage items."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Pot_Nova_6_Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8685,
+      "qwen_classification": "flowerpot",
+      "qwen_reasoning": "The object is a dark green, cylindrical container with a wide opening. Inside, there are three white circular marks: two small ones near the top and one larger one near the bottom. The shape and features suggest it is a type of plant pot or flowerpot, commonly used for growing plants. The white marks could be drainage holes or decorative elements. The overall form is consistent with a standard flowerpot design."
+    },
+    {
+      "asset_name": "gso_Android_Lego",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8214,
+      "qwen_classification": "Android mascot (uncertain)",
+      "qwen_reasoning": "The object is a stylized, lime-green figure with a blocky, geometric design. It has a distinct humanoid shape with two circular eyes, a white stripe across the chest, and appendages resembling arms and legs. This design is iconic and universally recognized as the Android mascot, which represents the Android operating system developed by Google. The object is not a real-world physical item but a digital representation of a brand logo or mascot."
+    },
+    {
+      "asset_name": "gso_Brother_LC_1053PKS_Ink_Cartridge_CyanMagentaYellow_1pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8330,
+      "qwen_classification": "printer ink cartridge packaging (uncertain)",
+      "qwen_reasoning": "The object is a cardboard packaging box for printer ink cartridges. The branding \"Brother\" is visible, along with model numbers \"LC105CL\" and \"XXL\" indicating extra high capacity. The box shows images of the ink cartridges (cyan, magenta, yellow) and includes text like \"VALUE PACK\" and \"3 CARTRIDGES\". This is clearly a retail package for printer consumables."
+    },
+    {
+      "asset_name": "gso_LEGO_5887_Dino_Defense_HQ",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8339,
+      "qwen_classification": "mechanical device (uncertain)",
+      "qwen_reasoning": "The object appears to be a complex, multi-part mechanical device with articulated arms, gears, and a central structure. It has a somewhat robotic or mechanical appearance, with yellow and black coloring, and features that resemble tools or weapons. The overall design suggests it is a piece of machinery, possibly from a video game or animated media, given its stylized and non-realistic construction. It does not resemble a common household item or natural object."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Best_of_Perricone_7Piece_Collection_MEGsO6GIsyL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8366,
+      "qwen_classification": "booklet (uncertain)",
+      "qwen_reasoning": "The object appears to be a rectangular, light-colored item with a textured surface and visible text or markings. The shape and texture suggest it could be a book, a pamphlet, or a folded document. The text is too faint and blurry to be legible, but the presence of printed content is evident. Given the context of being segmented and viewed at an angle, it is most likely a printed material such as a booklet or pamphlet."
+    },
+    {
+      "asset_name": "gso_Cole_Hardware_Mug_Classic_Blue",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8428,
+      "qwen_classification": "mug",
+      "qwen_reasoning": "The object is a ceramic or porcelain mug, characterized by its cylindrical shape, a handle on the side, and a wide opening. The color is a solid teal or turquoise. The surface appears smooth and glossy, typical of glazed ceramic tableware. The perspective is angled, showing the interior and the handle, which confirms it is a drinking vessel designed for holding liquids like coffee or tea."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_QP_Harvest",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8870,
+      "qwen_classification": "salt shaker",
+      "qwen_reasoning": "The object is a bright yellow, cube-shaped item with rounded edges and corners. On its top surface, there are six small, circular holes arranged in a 2x3 grid pattern. This design is characteristic of a salt or pepper shaker, which typically has holes for dispensing seasoning. The shape and hole configuration strongly suggest it is a kitchen condiment shaker, likely for salt given its common yellow color (though some salt shakers are white or clear)."
+    },
+    {
+      "asset_name": "gso_Playmates_nickelodeon_teenage_mutant_ninja_turtles_shredder",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8385,
+      "qwen_classification": "animated character (uncertain)",
+      "qwen_reasoning": "The object appears to be a stylized, possibly animated or video game character, shown in a dynamic, falling or tumbling pose. It has a bulky, armored appearance with purple and brownish tones, and features what look like wing-like or shield-like appendages on its back. The posture suggests motion and impact, and the overall design is not realistic but rather fantastical or cartoonish. The segmented white background confirms this is a cropped view of a single object."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_Quadra_Turquoise_QP12",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8635,
+      "qwen_classification": "gutter corner piece",
+      "qwen_reasoning": "The object is a three-dimensional, hollow, rectangular prism with rounded edges and corners. It appears to be made of a solid material, likely metal or plastic, with a matte blue finish. The shape is consistent with a gutter or downspout component, specifically a corner piece designed to connect two sections of gutter at a right angle. The visible internal channel confirms its function for water flow. The object is shown from an angled perspective, revealing its depth and the internal structure."
+    },
+    {
+      "asset_name": "gso_Canon_Pixma_Ink_Cartridge_251_M",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8691,
+      "qwen_classification": "ink cartridge (uncertain)",
+      "qwen_reasoning": "The object is a Canon ink cartridge, specifically model 251, as indicated by the text on the packaging. The packaging is red and white with the Canon logo, and the cartridge itself is visible, showing a magenta color indicator. This is a consumable for inkjet printers, designed to be inserted into a printer to provide ink for printing. The 'M' on the packaging likely stands for Magenta, which is the color of the ink in the cartridge."
+    },
+    {
+      "asset_name": "gso_Jansport_School_Backpack_Blue_Streak",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8691,
+      "qwen_classification": "backpack (uncertain)",
+      "qwen_reasoning": "The object is a blue, multi-compartment bag with zippers and a visible brand logo (Adidas) on the front pocket. Its shape, size, and features (multiple pockets, sturdy construction, and a top handle) are characteristic of a backpack or a large duffel bag designed for carrying personal items. The presence of a logo suggests it is a branded piece of luggage or gear."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Cold_Plasma_Body",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8601,
+      "qwen_classification": "product packaging box (uncertain)",
+      "qwen_reasoning": "The object is a rectangular, box-like item with a matte, brownish-gold color. It has visible text and a small logo or emblem on its side. The shape and appearance are consistent with a product packaging box, likely for a consumer electronic device or a similar product. The text is too blurry to read, but the overall form suggests it is not a natural object or a simple container like a jar or bottle. The presence of branding or labeling indicates it is commercial packaging."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_No_Mascara_Mascara",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8259,
+      "qwen_classification": "cardboard box",
+      "qwen_reasoning": "The object is a rectangular, beige-colored box with visible text and a barcode on its side. The shape and features are consistent with a standard cardboard packaging box, commonly used for shipping or storing products. The presence of a barcode and printed text suggests it is a commercial product package. The object appears to be a generic cardboard box, likely for an electronic device or similar item, given the typical design of such packaging."
+    },
+    {
+      "asset_name": "gso_Hefty_Waste_Basket_Decorative_Bronze_85_liter",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8718,
+      "qwen_classification": "water bottle",
+      "qwen_reasoning": "The object is a dark, cylindrical container with a smooth, slightly reflective surface. Its shape is consistent with a standard water bottle or a similar portable container. The white silhouette on the side appears to be a decorative or branding element, possibly a logo or graphic, which is common on water bottles. The object lacks any visible caps, spouts, or other features that would definitively identify it as a specific type of bottle, but its form factor strongly suggests it is a water bottle or a similar beverage container."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_No_Bronzer_Bronzer",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8619,
+      "qwen_classification": "medicine box (uncertain)",
+      "qwen_reasoning": "The object is a rectangular, white box with printed text and a barcode visible on one side. The presence of text (likely instructions, ingredients, or product information) and a barcode strongly suggests it is a commercial product package, commonly used for pharmaceuticals, supplements, or consumer goods. The box appears to be made of cardboard or similar packaging material. The perspective is angled, showing the top and one side of the box."
+    },
+    {
+      "asset_name": "gso_ALPHABET_AZ_GRADIENT_WQb1ufEycSj",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 7920,
+      "qwen_classification": "alphabet blocks",
+      "qwen_reasoning": "The image displays a collection of small, square blocks, each featuring a different uppercase letter of the alphabet. The blocks appear to be made of wood or a similar material and are arranged in a scattered, overlapping manner. Some blocks also have small, colorful illustrations (like an apple or a sun) alongside the letters, suggesting they are educational toys designed for children to learn letters. The overall appearance is consistent with alphabet blocks commonly used in early childhood education."
+    },
+    {
+      "asset_name": "gso_Mens_Bahama_in_White_vSwvGMCo32f",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8366,
+      "qwen_classification": "shoe (uncertain)",
+      "qwen_reasoning": "The object appears to be a light-colored, possibly beige or cream, shoe. It has a distinct shape with a curved upper, a visible seam or stitching line running vertically, and a small opening or slot near the top. The overall form suggests it is a type of footwear, likely a slip-on or low-top style. The texture and contours are consistent with a shoe, though the image is cropped and lacks context to identify the specific type (e.g., casual, athletic, or formal)."
+    },
+    {
+      "asset_name": "gso_Granimals_20_Wooden_ABC_Blocks_Wagon",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8229,
+      "qwen_classification": "grip (uncertain)",
+      "qwen_reasoning": "The object shown is a close-up of a black, cylindrical component with a textured surface, likely a grip or handle. It appears to be part of a larger tool or device, possibly a pen, a tool handle, or a grip for a mechanical device. The shape and material suggest it is designed for holding or operating something. The cropped view focuses on the grip area, which is common in tools or writing instruments to provide a secure hold."
+    },
+    {
+      "asset_name": "gso_Neat_Solutions_Character_Bib_2_pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8732,
+      "qwen_classification": "small serving dish (uncertain)",
+      "qwen_reasoning": "The object is a shallow, square-shaped container with rounded corners, viewed from directly above. It has a smooth, reflective surface with a metallic or glossy finish, indicated by the highlights and gradient shading. The interior is a solid purple color, while the exterior appears to be a darker, possibly bronze or copper tone. The shape and shallow depth suggest it is designed for holding small items, such as food, liquids, or decorative elements. This form factor is common for small serving dishes, condiment trays, or decorative bowls."
+    },
+    {
+      "asset_name": "gso_Cream_Tieks_Italian_Leather_Ballet_Flats",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8099,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a single shoe, likely a slip-on style such as a ballet flat or casual loafer. It has a smooth, light-colored upper (possibly white or off-white) and a visible insole. The shape is elongated and curved, consistent with footwear designed for the human foot. The view is angled, showing the side and top of the shoe. The black and brown markings near the opening suggest either a design element or the interior lining. Based on the visible features, it is clearly a piece of footwear."
+    },
+    {
+      "asset_name": "gso_Pokmon_Yellow_Special_Pikachu_Edition_Nintendo_Game_Boy_Color",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8538,
+      "qwen_classification": "eraser",
+      "qwen_reasoning": "The object is a bright yellow, rectangular item with rounded edges and a slightly textured surface. It appears to be a solid, rigid object, likely made of plastic or rubber. The shape and color are characteristic of a common household or office item. The top surface has some faint markings or text, which is typical for labeling products. Given its form factor and appearance, it is most likely a type of eraser, specifically a rectangular, yellow plastic eraser commonly used in schools or offices. The slight sheen and molded edges support this identification."
+    },
+    {
+      "asset_name": "gso_CHICKEN_RACER",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8700,
+      "qwen_classification": "toy skateboard (uncertain)",
+      "qwen_reasoning": "The object has a rounded, oval-shaped body with a smooth, light-colored surface, and four small, blue, wheel-like attachments at each corner. This configuration strongly suggests a toy vehicle, specifically a skateboard or a similar wheeled toy. The wheels are small and appear to be made of a soft material, which is common for children's toys. The overall design is simple and compact, consistent with a toy meant for play. The top-down view shows the object's symmetrical layout, reinforcing its function as a vehicle that rolls."
+    },
+    {
+      "asset_name": "gso_My_Little_Pony_Princess_Celestia",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8670,
+      "qwen_classification": "winged pony (uncertain)",
+      "qwen_reasoning": "The object is a stylized, cartoon-like pony with wings, likely from the 'My Little Pony' franchise. It has a white body, purple and gold accents, and is depicted in a dynamic, mid-flight pose. The presence of wings and the overall design suggest it is a fantasy creature, specifically a winged pony or pegasus. The object is clearly segmented from its background, with white pixels masking the surroundings, focusing attention on the pony itself."
+    },
+    {
+      "asset_name": "gso_BlackBlack_Nintendo_3DSXL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8661,
+      "qwen_classification": "portable media player",
+      "qwen_reasoning": "The object is a black, rectangular device with a slightly angled top edge and a small, light-colored label on its front surface. Its shape and form factor are consistent with a modern electronic device, likely a portable media player or a small digital audio player. The label suggests it has branding or model information, which is typical for consumer electronics. The overall design is compact and sleek, suggesting portability. While it could potentially be a small external hard drive or a similar gadget, the most likely classification based on common shapes and usage patterns is a portable media player."
+    },
+    {
+      "asset_name": "gso_Perricone_MD_Blue_Plasma_Orbital",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 9191,
+      "qwen_classification": "cosmetic product box",
+      "qwen_reasoning": "The object is a dark-colored, rectangular box with text and symbols printed on it. The visible text includes \"The Beauty\" and \"The Makeup,\" along with icons that appear to represent product features or usage instructions (such as an eye icon, a brush icon, and arrows). This packaging style, combined with the text, strongly suggests it is a cosmetic or beauty product box, likely for makeup items such as eyeshadow, eyeliner, or a makeup kit. The design is typical for beauty product packaging, which often includes branding and usage guidance."
+    },
+    {
+      "asset_name": "gso_JUNGLE_HEIGHT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7965,
+      "qwen_classification": "scroll display (uncertain)",
+      "qwen_reasoning": "The object appears to be a set of rolled-up papers or documents, possibly scrolls or posters, held together by a central rod or dowel. The visible edges show multiple layers, with some colored sections (green, blue, yellow) peeking out, suggesting they might be different documents or decorative elements. The rolled-up nature and the way they are stacked indicate they are meant to be displayed or stored in this manner. This is consistent with a decorative scroll display or a document holder."
+    },
+    {
+      "asset_name": "gso_Epson_273XL_Ink_Cartridge_Magenta",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8214,
+      "qwen_classification": "product packaging (uncertain)",
+      "qwen_reasoning": "The object is a rectangular cardboard package with a blue label on the front. The label contains text and small images, likely product information and branding. There is a hanging tab at the top, indicating it is designed for retail display on hooks. The overall shape and features are characteristic of a product box for consumer goods, such as printer ink cartridges, memory cards, or small electronic accessories. The presence of recycling symbols and a small logo at the bottom further supports that this is commercial packaging."
+    },
+    {
+      "asset_name": "gso_Kanex_MultiSync_Wireless_Keyboard",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 7744,
+      "qwen_classification": "electrical enclosure (uncertain)",
+      "qwen_reasoning": "The object is a rectangular, metallic-looking box with a small, dark square panel on its front face. The shape, material, and presence of a panel suggest it is an electrical or electronic enclosure, such as a junction box, control panel, or distribution box. The slight angle and visible edges indicate it is a physical, three-dimensional object. The dark square is likely a display, indicator, or access point. Given the context and appearance, it is most likely an electrical enclosure or panel."
+    },
+    {
+      "asset_name": "gso_MK7",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8549,
+      "qwen_classification": "pill bottle (uncertain)",
+      "qwen_reasoning": "The object is a cylindrical container with a white body and a yellow label wrapped around it. The label appears to have text and a barcode, which is typical for product packaging. The container has a slightly tapered top, suggesting it might be a cap or lid. The overall shape and labeling are consistent with a common type of consumer product packaging, such as a pill bottle, supplement container, or small jar. The white background and cropping suggest it's a product shot or a cropped image for identification purposes."
+    },
+    {
+      "asset_name": "gso_OXO_Soft_Works_Can_Opener_SnapLock",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 7976,
+      "qwen_classification": "handheld massager (uncertain)",
+      "qwen_reasoning": "The object shown is a black, ergonomic device with a curved handle and a rounded top section. This shape is characteristic of a handheld tool or controller designed for grip and operation. The form factor strongly resembles a handheld massager, a grip exerciser, or a specialized tool for physical therapy or rehabilitation. The smooth, contoured design suggests it is meant to be held comfortably in one hand. While it could be a generic handheld tool, the specific shape points toward a therapeutic or wellness device."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Planter_Pot_GP12AAvocado",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8752,
+      "qwen_classification": "flower pot",
+      "qwen_reasoning": "The object is a green, cylindrical container with a slightly flared rim and a visible seam running vertically along its side. Its shape and material (appearing to be plastic or molded material) are consistent with a small flower pot or plant container. The object is tilted, showing its side profile and part of its interior. There are no handles, spouts, or other features that would identify it as a different type of container. The texture appears smooth with some minor surface imperfections, typical of mass-produced plastic pots."
+    },
+    {
+      "asset_name": "gso_Black_Decker_CM2035B_12Cup_Thermal_Coffeemaker",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8813,
+      "qwen_classification": "handheld gaming console",
+      "qwen_reasoning": "The object is a black, rectangular device with a handle on top and a small display or button panel on the front. The shape and features are consistent with a portable electronic device, likely a handheld gaming console or a similar compact gadget. The handle suggests it is designed for portability and handheld use. The display panel indicates it has a screen or interface for user interaction. Based on the overall form factor and common consumer electronics, it most closely resembles a handheld gaming console, such as a Game Boy or similar device."
+    },
+    {
+      "asset_name": "gso_Melissa_Doug_Felt_Food_Pizza_Set",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8103,
+      "qwen_classification": "toy pizza (uncertain)",
+      "qwen_reasoning": "The object is a circular, flat food item that has been cut into four triangular slices, resembling a pizza. It has a crust and is topped with various colorful, cartoon-like decorations that look like toy food items (e.g., a red flower-like topping, a yellow smiley face, a green leaf, and pink circular pieces). The style is clearly stylized and not realistic, suggesting it is a toy or a decorative item rather than actual food. The white background indicates it has been cropped and segmented from a larger image."
+    },
+    {
+      "asset_name": "gso_Markings_Letter_Holder",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8633,
+      "qwen_classification": "product box",
+      "qwen_reasoning": "The object appears to be a dark brown, rectangular box with a slightly angled top surface. There is a visible label or sticker on one side, which is common for packaging. The shape and material suggest it could be a product box, possibly for electronics or consumer goods. The object is not a container with an opening, nor does it resemble a typical household item like a book or a case. The perspective shows it from an oblique angle, emphasizing its three-dimensional form. Given the context and appearance, it is most likely a packaged product box."
+    },
+    {
+      "asset_name": "gso_Playmates_Industrial_CoSplinter_Teenage_Mutant_Ninja_Turtle_Action_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8494,
+      "qwen_classification": "action figure (uncertain)",
+      "qwen_reasoning": "The object is a small, stylized figurine of a mouse or rat wearing a red robe or tunic. It has a long, thin tail, pointed ears, and is posed in a dynamic, running or leaping posture. The material appears to be plastic or resin, typical of collectible action figures or toys. The design is cartoonish and anthropomorphic, suggesting it is not a real animal but a representation of one, likely from a video game, movie, or animated series. The red garment and the pose give it a distinct character, possibly a villain or a comedic character."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_QP_Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8945,
+      "qwen_classification": "planter (uncertain)",
+      "qwen_reasoning": "The object is a square-shaped container with straight sides and a slightly tapered interior. It appears to be made of ceramic or a similar material, with a smooth, glazed finish. The color is a muted green or grayish-green. The shape and material suggest it is designed for holding small items, possibly for decorative or functional use. It resembles a small planter, a cup, or a decorative bowl. Given its simple, geometric form and lack of visible handles or spouts, it is most likely a small container or planter."
+    },
+    {
+      "asset_name": "gso_Marvel_Avengers_Titan_Hero_Series_Doctor_Doom",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7959,
+      "qwen_classification": "cloak (uncertain)",
+      "qwen_reasoning": "The object is a piece of fabric, specifically a cloak or cape, characterized by its flowing, draped shape and hooded top. The material appears soft and lightweight, with folds and creases typical of draped fabric. The color is a solid, vibrant green. The way it is presented, with the hood up and the body of the cloak falling in natural folds, strongly suggests it is a garment designed to be worn, likely for ceremonial, fantasy, or costume purposes. There are no visible fastenings, seams, or other structural elements that would identify it as a specific type of garment beyond being a cloak."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_Sofa",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8696,
+      "qwen_classification": "sofa (uncertain)",
+      "qwen_reasoning": "The object shown is a small, low-profile seating piece with a light-colored wooden frame and purple upholstered cushions. It has a backrest, a seat, and armrests, which are characteristic features of a sofa or couch. The size appears compact, suggesting it might be a loveseat or a small sofa, possibly designed for a child or as a decorative piece. The purple cushions are plush and appear to be fabric-covered, adding to its comfort and aesthetic appeal. The overall structure is simple and modern, with clean lines and a minimalist design."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_TablePurple",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8569,
+      "qwen_classification": "stand (uncertain)",
+      "qwen_reasoning": "The object has a flat, circular top surface and a base with three curved legs that splay outward. This design is characteristic of a small, stable stand or pedestal, often used to hold items like a cup, a small bowl, or a decorative object. The material appears to be plastic or a similar molded substance, given the smooth surfaces and uniform color. The overall shape is simple and functional, suggesting it is a utility item rather than a decorative or specialized piece. It resembles a small table or stand, possibly for a cake or a small item, but without more context, the most accurate classification is a stand or pedestal."
+    },
+    {
+      "asset_name": "gso_In_Green_Company_Surface_Saver_Ring_10_Terra_Cotta",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7962,
+      "qwen_classification": "wooden handle ring (uncertain)",
+      "qwen_reasoning": "The object is a circular, wooden ring with a light brown color and visible grain. It has six evenly spaced holes drilled around its perimeter. The bottom-left portion shows a darker, stained or worn area. This design is characteristic of a wooden ring used as a handle or grip for a tool, such as a mallet or hammer, or possibly a decorative or functional ring for a piece of furniture or equipment. The holes are likely for mounting or securing it to another object. Given the context and appearance, it is most likely a wooden handle ring or grip."
+    },
+    {
+      "asset_name": "gso_Ghost_6_GTX_Color_AnthBlckSlvrFernSulphSprng_Size_80",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8240,
+      "qwen_classification": "running shoe",
+      "qwen_reasoning": "The object in the image is a close-up view of a shoe, specifically focusing on the side and heel area. It features a combination of green, grey, and black colors with visible stitching and a textured sole. The design, including the lacing system and overall shape, is characteristic of athletic footwear. The green accents and the style suggest it could be a running or training shoe, possibly from a brand like Nike given the swoosh-like design element visible on the side. The cropped nature of the image and the white background indicate it is a segmented view of a larger object, but the visible features are sufficient to identify it as a shoe."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_SB9Turquoise",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8559,
+      "qwen_classification": "mechanical housing (uncertain)",
+      "qwen_reasoning": "The object is a curved, semi-cylindrical component with a flanged end that has multiple bolt holes. The shape and features suggest it is a mechanical part, likely designed to be mounted or attached to another structure. The flanged end with bolt holes indicates it is meant for secure fastening, possibly to a pipe, housing, or frame. The smooth, curved outer surface and the flat, bolted inner face are typical of components used in machinery or industrial equipment. It resembles a pipe coupling, a housing cover, or a part of a larger mechanical assembly."
+    },
+    {
+      "asset_name": "gso_Focus_8643_Lime_Squeezer_10x35x188_Enamelled_Aluminum_Light",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 7875,
+      "qwen_classification": "leaf (uncertain)",
+      "qwen_reasoning": "The object appears to be a dark green, curved, elongated shape with a distinct, somewhat pointed end. The form resembles a stylized leaf or a small, curved blade. Given the smooth, uniform color and the way it's presented, it could be a decorative element, a part of a plant, or even a stylized representation of a tool or weapon. However, without more context or additional views, it's difficult to be certain. The most plausible interpretation is that it is a leaf or a similar organic shape, but the abstract nature of the image makes a definitive identification challenging."
+    },
+    {
+      "asset_name": "gso_Closetmaid_Premium_Fabric_Cube_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8882,
+      "qwen_classification": "foldable stool (uncertain)",
+      "qwen_reasoning": "The object is a solid red, box-like structure with a visible seam or fold along one edge and a small, rectangular flap or handle on the top surface. The shape and construction suggest it is a collapsible or foldable item, likely made of fabric or flexible material. This design is typical of a portable stool, a footrest, or a small storage box that can be folded for compact storage. The presence of the flap/handle indicates it may be designed for easy carrying or opening. Given the context and appearance, it is most likely a foldable stool or ottoman."
+    },
+    {
+      "asset_name": "gso_Android_Figure_Panda",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8407,
+      "qwen_classification": "electronic component (uncertain)",
+      "qwen_reasoning": "The object appears to be a small, dark-colored, cylindrical device with a rounded top and two protruding sections on the sides. The top surface has a textured, possibly metallic or glass-like appearance with a reflective, iridescent quality. The overall shape and features suggest it could be a type of electronic component, a small container, or a specialized tool. However, without more context or additional views, it is difficult to determine its exact function or identity with certainty. The object's form is somewhat reminiscent of a small, sealed container or a component from a piece of machinery or electronics."
+    },
+    {
+      "asset_name": "gso_Grreatv_Choice_Dog_Bowl_Gray_Bones_Plastic_20_fl_oz_total",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8480,
+      "qwen_classification": "wristband (uncertain)",
+      "qwen_reasoning": "The object is a circular, cylindrical item with a smooth, metallic-looking surface. It has a pattern of small, white bone-shaped symbols printed or embossed on its side. The shape and design suggest it is a decorative or themed accessory, likely a wristband or bracelet. The bone motif is commonly associated with pet-related items, particularly dog accessories, or with themes like Halloween or gothic fashion. The object appears to be made of a flexible material, possibly silicone or rubber, given its slight curvature and the way it's presented. It is not a functional item like a bottle or tool, but rather a wearable piece of jewelry or a novelty item."
+    },
+    {
+      "asset_name": "gso_Chef_Style_Round_Cake_Pan_9_inch_pan",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8264,
+      "qwen_classification": "shallow dish (uncertain)",
+      "qwen_reasoning": "The object is a circular, black, flat item with a slightly raised rim, viewed from above. It has a small, square, white label or barcode sticker in the center. This shape and appearance are characteristic of a shallow, round container, commonly used for food or liquids. The label suggests it is a commercial product, likely for retail. The most plausible identification is a shallow dish or plate, possibly a baking dish or a serving platter, given its depth and rim. It could also be a lid for a container, but the presence of a label and the overall shape make a dish more likely."
+    },
+    {
+      "asset_name": "gso_KITCHEN_SET_CLASSIC_40HwCHfeG0H",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8767,
+      "qwen_classification": "remote control (uncertain)",
+      "qwen_reasoning": "The object appears to be a small, light-colored, rectangular device with a hinged or foldable design. It has a circular button or sensor on one side and three vertical lines above it, which could be indicator lights or decorative elements. The overall shape and features suggest it might be a portable electronic device, possibly a remote control, a small gadget, or a component of a larger system. The hinge-like structure indicates it can be folded or opened, which is common in devices like foldable remotes or compact tools. However, without more context or a clearer view, it's difficult to be certain of its exact function."
+    },
+    {
+      "asset_name": "gso_Ecoforms_Plant_Container_URN_NAT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8762,
+      "qwen_classification": "lampshade (uncertain)",
+      "qwen_reasoning": "The object is a conical or tapered shape with a wide opening at one end and a narrower base. The surface appears to be made of a textured material, possibly ceramic or a similar substance, with a warm, earthy color. The open end reveals a circular rim with small holes, which suggests it may be designed for mounting or securing something. This form and construction are characteristic of a lampshade or a decorative container, but the holes at the base are a key feature that points toward a functional purpose, such as a lampshade for a pendant light or a specialized container. Given the shape and the mounting holes, it is most likely a lampshade, possibly for a ceiling or pendant fixture."
+    },
+    {
+      "asset_name": "gso_Dino_5",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8240,
+      "qwen_classification": "dinosaur (uncertain)",
+      "qwen_reasoning": "The object in the image has a bulky, rounded body with a distinct head and two prominent, curved horns on top. It appears to be a quadrupedal creature, though the limbs are somewhat obscured. The overall shape and features strongly suggest a dinosaur, specifically a ceratopsian like a Triceratops, which is known for its large frill and horns. The posture, with the head tilted back and the body arched, might indicate movement or a specific pose, but the key identifying features are the horns and the overall body structure. The image quality is low, but the silhouette is unmistakable for a horned dinosaur."
+    },
+    {
+      "asset_name": "gso_BAGEL_WITH_CHEESE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8476,
+      "qwen_classification": "toy (uncertain)",
+      "qwen_reasoning": "The object is a small, round, flat item with a light brown, textured surface that resembles a pancake or a small bread-like item. It has a small red and green protrusion on one side, which appears to be a handle or decorative element. The overall shape and design suggest it is a toy or a novelty item, possibly shaped like a hamburger or a taco, given the colors and the way it's presented. The text embossed on the surface is too small and unclear to read, but it likely indicates branding or a name. The object is not a real food item, as it appears to be made of plastic or a similar material, and its design is stylized for play or decoration."
+    },
+    {
+      "asset_name": "gso_CHICKEN_NESTING",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8478,
+      "qwen_classification": "stacking toy (uncertain)",
+      "qwen_reasoning": "The object is a stack of colorful, nested cups or bowls, each slightly smaller than the one above it, with a small white ball at the bottom. The design resembles a classic children's toy, often called a 'nesting cup' or 'stacking cup' toy. The cups are brightly colored (orange, red, yellow) and have simple facial features (eyes) drawn on them, which is typical for toys designed for young children. The way they are stacked and the presence of the ball suggest it is meant to be played with by dropping the ball or stacking the cups. This is not a functional container or a piece of furniture, but a play item."
+    },
+    {
+      "asset_name": "gso_Poise_Ultimate_Pads_Long",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8773,
+      "qwen_classification": "product box (uncertain)",
+      "qwen_reasoning": "The object appears to be a rectangular package with a glossy, purple and pink color scheme. It has a distinct shape with visible edges and corners, suggesting it is a manufactured product in a box or wrapper. The surface has a sheen, indicating it might be made of plastic or laminated paper. The design is typical of consumer goods packaging, such as for cosmetics, snacks, or personal care items. The way it is angled and the lighting create highlights and shadows, confirming it is a three-dimensional object. Given the common packaging styles and the color palette, it is likely a product box, but without text or specific branding visible, the exact product type cannot be definitively identified."
+    },
+    {
+      "asset_name": "gso_3D_Dollhouse_Sink",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8543,
+      "qwen_classification": "bracket (uncertain)",
+      "qwen_reasoning": "The object appears to be a solid, three-dimensional block with a distinct L-shaped or corner-like profile. It has a dark, matte finish on most surfaces, with one visible face showing a lighter, possibly metallic or gold-colored material. The geometry suggests it is a manufactured component, possibly a bracket, a connector, or a decorative element. The sharp edges and right angles indicate it is not organic or naturally occurring. Given its shape and material appearance, it could be a part of a larger assembly, such as a mounting bracket, a structural support, or a piece of furniture hardware. Without more context, it is difficult to determine its exact function, but its form strongly suggests it is a mechanical or architectural component."
+    },
+    {
+      "asset_name": "gso_BIA_Cordon_Bleu_White_Porcelain_Utensil_Holder_900028",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8926,
+      "qwen_classification": "small container (uncertain)",
+      "qwen_reasoning": "The object is a gray, cylindrical container with a slightly flared rim and a cut-out section on its side. The cut-out appears to be a decorative or functional feature, possibly for ventilation or to reduce weight. The overall shape and material suggest it is a utilitarian item, likely made of plastic or metal. It resembles a small bucket, a planter, or a container for holding small items. The cut-out is not typical of a standard bucket or planter, which makes it more likely to be a specialized container, possibly for a specific use like a small trash can, a holder, or a component of a larger device. Without more context, the most reasonable classification is a small container with a cut-out feature."
+    },
+    {
+      "asset_name": "gso_Hasbro_Dont_Wake_Daddy_Board_Game_NJnjGna4u1a",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 7931,
+      "qwen_classification": "geometric object (uncertain)",
+      "qwen_reasoning": "The object is a solid, curved, blue item with a smooth surface and a slightly tapered shape. It appears to be a single, continuous piece without any visible seams, handles, or functional features like a nozzle or button. The shape is somewhat cylindrical or conical, but the exact form is ambiguous due to the limited view. It could be a component of a larger device, a decorative item, or a simple geometric shape. Given the lack of context and the abstract nature of the shape, it is difficult to determine its precise function or identity. It does not resemble common everyday objects like a bottle, cup, or tool. The most reasonable classification is a generic geometric object or a part of a device, but without more information, a specific functional classification is not possible."
+    },
+    {
+      "asset_name": "gso_Olive_Kids_Paisley_Pencil_Case",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8328,
+      "qwen_classification": "headband",
+      "qwen_reasoning": "The object is a curved, elongated item with a distinct shape that suggests it is a piece of fabric or a soft material. The surface is covered in a colorful, repeating pattern of paisley and floral motifs in shades of pink, orange, yellow, and blue. The way it is folded or draped, along with the visible seams or edges, indicates it is likely a wearable item or a decorative textile. Given the shape and pattern, it most closely resembles a headband or a decorative hair accessory, possibly a scarf or a bandana, but the specific curvature and lack of visible fasteners or ties make a headband the most plausible identification. The object appears to be made of a soft, flexible material, consistent with fabric used for headwear or accessories."
+    },
+    {
+      "asset_name": "gso_Creatine_Monohydrate",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8522,
+      "qwen_classification": "powder container",
+      "qwen_reasoning": "The object is a cylindrical container with a white or light gray body and a label wrapped around its side. The label appears to have text and possibly a barcode, which is typical for commercial packaging. The shape and labeling suggest it is a product container, likely for a powder, granules, or liquid. The top appears to be a flat, sealed lid, indicating it is a closed container. This is consistent with packaging for items like salt, sugar, spices, or powdered supplements. The object is not a bottle with a neck or cap, nor is it a can with a pull-tab or seam typical of beverage cans. It is also not a jar with a screw-on lid. The most likely classification is a powder container or a similar type of packaged food or supplement."
+    },
+    {
+      "asset_name": "gso_Poppin_File_Sorter_White",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8780,
+      "qwen_classification": "storage rack",
+      "qwen_reasoning": "The object shown is a metal rack with a flat top surface and multiple curved legs supporting it. The design is typical of a utility or storage rack, often used for holding items like trays, baskets, or other small objects. The curved legs suggest it is designed to be stable while allowing for easy stacking or nesting. The overall structure is open and functional, consistent with a storage or display rack."
+    },
+    {
+      "asset_name": "gso_RedBlack_Nintendo_3DSXL",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8841,
+      "qwen_classification": "gaming console (Nintendo 3DS)",
+      "qwen_reasoning": "The object is a red handheld gaming console with a black hinge and visible internal components along the edge. The shape, color, and design are characteristic of the Nintendo 3DS, a popular portable gaming device. The visible hinge suggests it can fold, which is a key feature of the 3DS. The red color is a common variant of this console. The white background is masking the surrounding environment, focusing attention on the device itself."
+    },
+    {
+      "asset_name": "gso_Pony_C_Clamp_1440",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8314,
+      "qwen_classification": "C-clamp",
+      "qwen_reasoning": "The object shown is a C-clamp, which is a type of mechanical clamp. It has a distinctive C-shaped frame with a threaded screw mechanism that allows the jaws to be tightened or loosened. The screw is operated by a handle, which is visible at the bottom right. This tool is commonly used in woodworking, metalworking, and other crafts to hold materials together firmly while gluing, drilling, or cutting. The object's shape, mechanism, and function are all characteristic of a C-clamp."
+    },
+    {
+      "asset_name": "gso_Theanine",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 8393,
+      "qwen_classification": "medicine bottle",
+      "qwen_reasoning": "The object is a small, cylindrical container with a white body and a blue label. The shape, cap, and labeling are characteristic of a medicine bottle or supplement container. The label appears to have text and possibly dosage information, which is typical for pharmaceutical or health-related products. The object is tilted, but its form is clearly that of a bottle designed for holding pills or capsules."
+    },
+    {
+      "asset_name": "gso_Racoon",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8161,
+      "qwen_classification": "plush toy (uncertain)",
+      "qwen_reasoning": "The object appears to be a plush toy or stuffed animal, likely representing a cat or similar feline creature. This is suggested by the fluffy, textured material, the presence of what looks like a tail (with a dark and white pattern), and the overall shape that resembles an animal's body. The gray and white coloration is common for cat-themed plush toys. The object is segmented from its background, which is consistent with the provided context."
+    },
+    {
+      "asset_name": "gso_Womens_Canvas_Bahama_in_Black_vnJULsDVyq5",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8168,
+      "qwen_classification": "shoe",
+      "qwen_reasoning": "The object appears to be a shoe, specifically viewed from the side or bottom. It has a curved, elongated shape with a distinct sole and heel area. The color is primarily gray or light blue with darker accents, and there is a small rectangular label or logo visible on the side. The overall form and features are consistent with a shoe, likely a casual or athletic style."
+    },
+    {
+      "asset_name": "gso_Seagate_3TB_Central_shared_storage",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8267,
+      "qwen_classification": "power adapter (uncertain)",
+      "qwen_reasoning": "The object is a dark-colored, rectangular electronic device with a perforated surface, likely for ventilation. It has a label with text and symbols, including what appears to be regulatory markings (e.g., 'CE' and 'FCC'). The shape and features are consistent with a power adapter or a small electronic device's housing. The perforations suggest it needs airflow, which is common for devices that generate heat. The overall form factor is compact and utilitarian, typical of consumer electronics accessories."
+    },
+    {
+      "asset_name": "gso_Threshold_Tray_Rectangle_Porcelain",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8300,
+      "qwen_classification": "laptop (uncertain)",
+      "qwen_reasoning": "The object is a flat, rectangular item with rounded corners and a smooth, light-colored surface. The shape and appearance are consistent with a modern, minimalist laptop computer, specifically the lid or top casing. The slight perspective suggests it's viewed at an angle, and the clean lines and uniform color are characteristic of contemporary laptop designs. The white masking around the edges indicates it has been cropped from a larger image, but the object itself is clearly identifiable as a laptop."
+    },
+    {
+      "asset_name": "gso_Room_Essentials_Fabric_Cube_Lavender",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8961,
+      "qwen_classification": "fabric storage bin",
+      "qwen_reasoning": "The object is a cube-shaped container made of fabric, with a visible dark interior and a solid maroon exterior. It appears to be collapsible or foldable, as suggested by the seams and the way the fabric is constructed. There is a small circular handle or loop on one side, indicating it is designed for portability. This type of object is commonly used for storage, organizing items, or as a decorative basket. The shape and material are consistent with a fabric storage bin or collapsible basket."
+    },
+    {
+      "asset_name": "gso_Reebok_TRIPLE_BREAK_LITE",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8123,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object is a single athletic shoe, viewed from a side angle. It has a light gray or white upper with perforations for ventilation, a padded collar, and a teal-colored accent on the tongue. The sole appears to be a standard athletic shoe sole with a slight heel elevation. These features are characteristic of a casual or athletic sneaker, likely designed for everyday wear or light activity. The object is clearly segmented from the background, and the white areas are just the mask, not part of the shoe."
+    },
+    {
+      "asset_name": "gso_Threshold_Basket_Natural_Finish_Fabric_Liner_Small",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8696,
+      "qwen_classification": "cleaning sponge (uncertain)",
+      "qwen_reasoning": "The object appears to be a rectangular block with a textured, porous surface on one side, resembling a sponge or a porous material. The other side is covered with a brown, flexible material that looks like paper or thin fabric, which is folded or wrapped around the block. The overall shape is cuboid, and the material on the side suggests it might be a sponge used for cleaning or absorption, possibly wrapped in a protective or decorative cover. The texture and appearance are consistent with a cleaning sponge, often used in kitchens or bathrooms."
+    },
+    {
+      "asset_name": "gso_Timberland_Mens_Earthkeepers_Stormbuck_Plain_Toe_Oxford",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8136,
+      "qwen_classification": "shoe (uncertain)",
+      "qwen_reasoning": "The object is a single brown shoe with a thick, black, treaded sole. It appears to be a casual or work-style shoe, possibly a loafer or a slip-on boot, given the lack of visible laces and the overall design. The sole has a rugged, textured pattern, suggesting it is designed for durability or grip. The color is a solid dark brown, and the material looks like leather or a synthetic equivalent. The view is a side profile, showing the shoe's silhouette and sole structure."
+    },
+    {
+      "asset_name": "gso_Womens_Sequin_Bahama_in_White_Sequin_XoR8xTlxj1g",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8111,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The image shows a close-up of a dark blue canvas shoe with white laces and a white rubber sole. The visible stitching and the overall design are characteristic of a classic low-top sneaker, commonly known as a canvas shoe or sneaker. The angle suggests it's a side view focusing on the heel and midsection. The material appears to be canvas, and the construction is typical of casual footwear."
+    },
+    {
+      "asset_name": "gso_SORTING_TRAIN",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8339,
+      "qwen_classification": "pull-along toy (uncertain)",
+      "qwen_reasoning": "The object is a colorful, multi-part toy with a blue rectangular body, red wheels, and a handle with red knobs. It has a rope attached for pulling, and the body appears to be designed to hold or display other colorful elements (possibly balls or blocks) inside or on top. This design is characteristic of a classic pull-along toy, often used by young children for play and motor skill development. The segmented, cropped view suggests it's a toy vehicle or walker that is pulled by a child."
+    },
+    {
+      "asset_name": "gso_Razer_BlackWidow_Stealth_2014_Keyboard_07VFzIVabgh",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_008.png"
+      ],
+      "total_views_available": 8099,
+      "qwen_classification": "water bottle (uncertain)",
+      "qwen_reasoning": "The object is a dark, elongated, cylindrical item with a textured surface that appears to be covered in small, raised dots or bumps. It has a tapered end and a slightly wider base. The shape and texture are consistent with a type of portable container, possibly for holding liquids or small items. The presence of a small, coiled cord or strap attached to one end suggests it may be a device or a container with a closure mechanism. Given the shape and texture, it most closely resembles a water bottle or a similar portable container, though the exact function is not certain without more context."
+    },
+    {
+      "asset_name": "gso_Teenage_Mutant_Ninja_Turtles_Rahzar_Action_Figure",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_005.png"
+      ],
+      "total_views_available": 8325,
+      "qwen_classification": "mechanical creature (uncertain)",
+      "qwen_reasoning": "The object appears to be a dark, stylized, and somewhat abstract representation of a mechanical or robotic entity. It has multiple articulated limbs or appendages extending from a central body, with a complex, gear-like or segmented structure. The overall form suggests a mechanical creature or a piece of machinery, possibly from a video game or animated media, given its exaggerated and non-realistic design. The lack of clear human or animal features, combined with the mechanical appearance, points away from organic or conventional objects."
+    },
+    {
+      "asset_name": "gso_Threshold_Textured_Damask_Bath_Towel_Pink",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8725,
+      "qwen_classification": "towel",
+      "qwen_reasoning": "The object is a folded textile item with a soft, plush appearance and a subtle pattern. Its texture and the way it is folded suggest it is made of a fabric material, likely cotton or a similar absorbent fiber. The color is a light pink or lavender, and the pattern appears to be a floral or damask design, which is common on towels or bath linens. The object's shape and material are consistent with a towel, specifically a bath towel or hand towel, given its typical use and appearance."
+    },
+    {
+      "asset_name": "gso_Xyli_Pure_Xylitol",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_007.png"
+      ],
+      "total_views_available": 8533,
+      "qwen_classification": "xylitol container",
+      "qwen_reasoning": "The object is a cylindrical container, likely made of plastic or metal, with a label that clearly reads \"Xylitol\" and \"Xyl Pure\". The branding \"FastLane\" is also visible. This indicates it is a commercial product, specifically a container of xylitol, which is a sugar alcohol used as a sweetener and dental health product. The shape and labeling are consistent with a bulk or retail container for powdered or granulated xylitol."
+    },
+    {
+      "asset_name": "gso_Womens_Bluefish_2Eye_Boat_Shoe_in_Tan",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7993,
+      "qwen_classification": "sneaker",
+      "qwen_reasoning": "The object shown is a shoe, specifically a sneaker or athletic shoe. It has a distinct sole with visible stitching and a layered construction, including a white midsole and a darker outsole. The upper part appears to be made of leather or a similar material, with a curved, elongated shape typical of athletic footwear. The presence of lacing eyelets (visible as small circular holes) and the overall form strongly indicate it is a shoe designed for walking or sports."
+    },
+    {
+      "asset_name": "gso_Threshold_Dinner_Plate_Square_Rim_White_Porcelain",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8484,
+      "qwen_classification": "tray (uncertain)",
+      "qwen_reasoning": "The object appears to be a rectangular, flat item with a smooth, slightly reflective surface. The way light reflects off its surface suggests it is made of a rigid material, possibly plastic or metal. The edges are straight and the corners are slightly rounded. Given its shape and appearance, it is most likely a small, flat container or a lid. It could be a small tray, a lid for a container, or a decorative plaque. Without more context, it is difficult to be certain, but the most plausible classification is a small tray or lid."
+    },
+    {
+      "asset_name": "gso_Sapota_Threshold_4_Ceramic_Round_Planter_Red",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8706,
+      "qwen_classification": "cup (uncertain)",
+      "qwen_reasoning": "The object is a red, cylindrical item with a slightly tapered shape, appearing to be made of a smooth, possibly plastic material. It has a circular opening at one end, which is bordered by a white rim. The interior of the opening shows a small, circular purple detail. The overall shape and features suggest it is a container or vessel, likely designed to hold something. The tapered form and the opening are characteristic of a cup or a small bucket. The purple detail might be a logo or a design element. Given its shape and features, it is most likely a small cup or a similar container."
+    },
+    {
+      "asset_name": "gso_Spectrum_Wall_Mount",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8549,
+      "qwen_classification": "display tag (uncertain)",
+      "qwen_reasoning": "The object appears to be a small, rectangular, transparent or semi-transparent container with a white plastic frame or holder. It has two curved white handles or loops on either side, suggesting it is designed to be hung or carried. The container seems to hold a small item, possibly a card, label, or small product, as indicated by the faint text and blue graphic visible inside. This design is typical of a product display tag, a small sign holder, or a promotional item for retail environments. The overall structure is lightweight and portable, consistent with a display or informational tag."
+    },
+    {
+      "asset_name": "gso_TOOL_BELT",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8334,
+      "qwen_classification": "toy car (uncertain)",
+      "qwen_reasoning": "The object appears to be a small, toy-like vehicle, possibly a car or a robot. It has a beige or tan body with blue and red accents. There are visible wheels (one red wheel is clearly visible on the right side), and the overall shape suggests a compact, possibly futuristic or cartoonish design. The construction looks blocky and stylized, consistent with a toy or a character from a video game or animated series. The presence of what might be a handle or arm-like structure on the left side further supports the idea that it's a toy vehicle or robot."
+    },
+    {
+      "asset_name": "gso_Thomas_Friends_Wooden_Railway_Ascending_Track_Riser_Pack",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 7947,
+      "qwen_classification": "handrail (uncertain)",
+      "qwen_reasoning": "The object shown is a three-dimensional, curved structure with a light brown, wood-like texture. It has a distinct S-shape with three horizontal, stepped platforms or rungs. This form is characteristic of a decorative or functional handrail, stair rail, or possibly a piece of furniture like a bench or a stylized sculpture. The stepped design suggests it is meant to be grasped or supported, and the material appearance points to wood or a wood-like composite. Given the context of being segmented and viewed from a single angle, it is most likely a component of a staircase or railing system."
+    },
+    {
+      "asset_name": "gso_Schleich_Allosaurus",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_010.png"
+      ],
+      "total_views_available": 7997,
+      "qwen_classification": "lizard (uncertain)",
+      "qwen_reasoning": "The object in the image has the distinct shape of a small reptile, characterized by a long, curved tail, four legs, and a body with a textured, scaly appearance. The coloration is primarily brown with darker stripes or patterns, which is common in many lizard species. The posture suggests it is in motion, possibly walking or running. Based on these visual features, it is most likely a type of lizard, possibly a monitor lizard or a similar ground-dwelling reptile. The image quality is low-resolution and pixelated, which makes precise identification difficult, but the overall form is unmistakably that of a reptile."
+    },
+    {
+      "asset_name": "gso_Whey_Protein_Vanilla",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_003.png"
+      ],
+      "total_views_available": 8370,
+      "qwen_classification": "jar (uncertain)",
+      "qwen_reasoning": "The object is a white, cylindrical container with a matching white lid. It has a label wrapped around its body, which appears to have blue and yellow/gold design elements. The shape and labeling suggest it is a commercial product, likely for consumer use. Given its form, it is most likely a jar or bottle for storing substances such as powder, cream, or pills. The label design hints at it being a product for personal care or health, but without readable text, the exact contents cannot be determined. The object is clearly a container, not a food item or a tool."
+    },
+    {
+      "asset_name": "gso_Tory_Burch_Sabe_65mm_Bootie_Split_Suede_in_Caramel",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_001.png"
+      ],
+      "total_views_available": 8360,
+      "qwen_classification": "wooden shoe (uncertain)",
+      "qwen_reasoning": "The object shown is a wooden item with a distinct shape that includes a heel and a sole. It appears to be a single piece of wood, possibly carved or molded, with a curved top surface and a textured heel area. The shape is consistent with a traditional wooden shoe or clog, which is often worn as footwear or used as a decorative or functional item. The lack of laces, stitching, or other typical shoe components suggests it is not a modern shoe but rather a more rustic or historical style. The object's form and material strongly indicate it is a wooden shoe or clog."
+    },
+    {
+      "asset_name": "gso_Threshold_Salad_Plate_Square_Rim_Porcelain",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_002.png"
+      ],
+      "total_views_available": 8550,
+      "qwen_classification": "plate (uncertain)",
+      "qwen_reasoning": "The object appears to be a flat, rectangular item with rounded corners, likely made of a smooth, light-colored material such as plastic or ceramic. The perspective is angled, showing a portion of its top surface and one side. The small, irregularly shaped fragment near the bottom right corner suggests it might be a broken or detached piece, possibly from a larger item like a plate, tray, or lid. Given its shape and the context of being segmented from a scene, it most closely resembles a small plate or a shallow dish. The lack of any visible handles, patterns, or other identifying features makes a precise identification difficult, but the overall form is consistent with a simple, utilitarian dish."
+    },
+    {
+      "asset_name": "gso_Sterilite_Caddy_Blue_Sky_17_58_x_12_58_x_9_14",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_004.png"
+      ],
+      "total_views_available": 8794,
+      "qwen_classification": "handle (uncertain)",
+      "qwen_reasoning": "The object is a solid, blue, cylindrical item with a curved, open top and a visible circular cutout on its side. Its shape and features suggest it is a component of a larger device, possibly a handle or a part of a tool. The cutout could be for mounting, gripping, or alignment. Given its form, it is most likely a handle or grip component for a tool or piece of equipment, such as a wrench handle, a tool holder, or a part of a mechanical device. The material appears to be plastic or rubberized plastic, common for ergonomic grips. Without more context, it is difficult to be certain of its exact function, but its most plausible classification is a handle or grip component."
+    },
+    {
+      "asset_name": "gso_Schleich_Therizinosaurus_ln9cruulPqc",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_009.png"
+      ],
+      "total_views_available": 8404,
+      "qwen_classification": "dinosaur (theropod) (uncertain)",
+      "qwen_reasoning": "The object depicted is a bipedal, feathered dinosaur with a long tail, long arms with three-fingered hands, and a relatively small head. Its posture is upright and alert, with its head raised and one arm slightly raised. The coloration includes shades of orange, yellow, and blue-gray. These features are characteristic of a theropod dinosaur, specifically one that is likely a dromaeosaurid (often called a 'raptor'), such as Velociraptor or Deinonychus. The presence of feathers is a key indicator of its classification within the theropod group, as many non-avian theropods were feathered. The overall appearance is consistent with a digital rendering or model of a prehistoric animal."
+    },
+    {
+      "asset_name": "gso_WHALE_WHISTLE_6PCS_SET",
+      "dataset": "gso",
+      "num_crops_available": 10,
+      "num_crops_used": 1,
+      "selected_crops": [
+        "crop_006.png"
+      ],
+      "total_views_available": 8521,
+      "qwen_classification": "decorative figurine (uncertain)",
+      "qwen_reasoning": "The object shown is a close-up of a smooth, curved, light blue surface with a small protrusion on the right side. The texture appears slightly speckled or mottled, which is common in molded plastic or ceramic objects. The shape is rounded and organic, lacking any clear functional features like handles, spouts, or hinges. Given the context of a cropped, segmented view, this could be a part of a larger object, such as the top of a container, a decorative item, or a toy. The most plausible classification is a small decorative figurine or a part of a molded object, but without more context, it's difficult to be certain. The rounded shape and color suggest it might be a toy or a decorative piece, possibly resembling a stylized animal or abstract form."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #10.

Previously, `scripts/data_prep/foundationpose/` only shipped `convert_foundationpose_fast.py` (the final Omni3D-conversion step). External users following the README hit a format mismatch because the prior two steps were never released. This PR adds them.

## What's new

- **`extract_foundationpose.py`** (Step 1): unpack the raw FoundationPose zip archives from the official Google Drive into the structured per-frame layout (`images/`, `depth/`, `camera_params/`, `masks/`, `scene_data/`, ...). Output format is documented in `EXTRACTED_FORMAT.md`.

- **`convert_gso_to_3dbbox.py`** (Step 2): read the extracted directory and produce one `step30_result_{image_id}.json` per image, matching the per-image 3D bbox format used by the COCO / Objects365 / LVIS preprocessing pipelines. Internal `/weka/` defaults have been replaced with required `--base_dir` / `--output_dir` CLI args.

- **`gso_qwen_classifications_v2.json`** (741 KB): pre-computed Qwen-VLM category labels for the 928 GSO assets. Step 2 needs these to assign natural-language categories, but they were not produced by Step 1 in the previous release, causing a hidden `FileNotFoundError`. The JSON is now shipped alongside the scripts so the pipeline works without re-running the VLM. Step 2 picks it up via a 3-step path resolution: `--qwen_classifications` CLI override → `<base_dir>/qwen_classifications_v2/...` → the JSON co-located with the script.

- **`README.md`**: end-to-end walkthrough of the three steps with example CLI invocations and the expected layout after each step.

## Validation

Validated end-to-end on a freshly downloaded zip from the official FoundationPose Google Drive (`1004491151.zip`, 5.5 GB):

| Step | Result |
| --- | --- |
| Step 1 (extract) | 51 s; 6,974 images / depth / camera_params / scene_data / instance_mappings extracted |
| Step 2 (3D bbox) | 0.2 s on 5 images; 92 objects, 50 categories, with the bundled Qwen JSON auto-loaded |
| Step 3 (Omni3D) | `FoundationPose_train.json` emitted with the expected Omni3D fields (`images`, `annotations`, `categories`) |
