### PR TITLE
docs: add stage 1 and stage 2 intermediate checkpoint download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,22 @@
 | WildDet3D | SAM3 ViT | LingBot-Depth (DINOv2 ViT-L/14) | ~1.2B | [allenai/WildDet3D](https://huggingface.co/allenai/WildDet3D) |
 
 ```bash
-# Download checkpoint
+# Download the released paper checkpoint (~4.7 GB)
 pip install huggingface_hub
 huggingface-cli download allenai/WildDet3D wilddet3d_alldata_all_prompt_v1.0.pt --local-dir ckpt/
 ```
+
+**Intermediate checkpoints (for partial reproduction of the 3-stage training):**
+
+```bash
+# Stage 1 -- Omni3D-only canonical, 12 epochs (~4.7 GB)
+huggingface-cli download allenai/WildDet3D wilddet3d_stage1_omni3d_12e_v1.0.pt --local-dir ckpt/
+
+# Stage 2 -- 8-dataset all-data finetune from Stage 1, 12 epochs (~4.7 GB)
+huggingface-cli download allenai/WildDet3D wilddet3d_stage2_alldata_12e_v1.0.pt --local-dir ckpt/
+```
+
+See [`docs/TRAINING.md`](docs/TRAINING.md) for how to load these as the starting point of the next stage.
 
 ## Installation
 

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -56,6 +56,12 @@ MIXED_PRECISION=bf16 vis4d fit \
 
 **Output:** `vis4d-workspace/wilddet3d_stage1_omni3d/checkpoints/epoch=11-step=XXXX.ckpt`
 
+> **Skip Stage 1 — download the released checkpoint:** to start from a pretrained Stage 1 ckpt instead of running 12 epochs, grab it from HuggingFace:
+> ```bash
+> huggingface-cli download allenai/WildDet3D wilddet3d_stage1_omni3d_12e_v1.0.pt --local-dir ckpt/
+> ```
+> Same format as the released `wilddet3d_alldata_all_prompt_v1.0.pt` (state_dict + epoch/step + hparams, ~4.7 GB, optimizer state stripped). Pass it as `--ckpt ckpt/wilddet3d_stage1_omni3d_12e_v1.0.pt` to the Stage 2 command below.
+
 ### Stage 2: All-Data Dense Finetune
 
 Load Stage 1 checkpoint, train on 8 datasets with the plain 5-mode collator (text + box prompts, no mask):
@@ -82,6 +88,12 @@ MIXED_PRECISION=bf16 vis4d fit \
 Uses the plain `5mode` collator (text + box geometry prompts); point prompts sampled from masks are introduced in Stage 3.
 
 **Output:** `vis4d-workspace/wilddet3d_stage2_alldata/checkpoints/epoch=11-step=XXXX.ckpt`
+
+> **Skip Stage 2 — download the released checkpoint:** to start the Stage 3 finetune from a pretrained Stage 2 ckpt instead of running 12 epochs on 4 nodes, grab it from HuggingFace:
+> ```bash
+> huggingface-cli download allenai/WildDet3D wilddet3d_stage2_alldata_12e_v1.0.pt --local-dir ckpt/
+> ```
+> Same format as the released `wilddet3d_alldata_all_prompt_v1.0.pt` (state_dict + epoch/step + hparams, ~4.7 GB, optimizer state stripped). Pass it as `--ckpt ckpt/wilddet3d_stage2_alldata_12e_v1.0.pt` to the Stage 3 command below.
 
 ### Stage 3: High-Quality Mix-Prompt Finetune
 


### PR DESCRIPTION
Requested in #20.

The stage 1 (Omni3D-only canonical, 12 ep) and stage 2 (all-data finetune, 12 ep) intermediate checkpoints from the 3-stage training pipeline have been uploaded to [allenai/WildDet3D](https://huggingface.co/allenai/WildDet3D) on HuggingFace (see HF PR https://huggingface.co/allenai/WildDet3D/discussions/1).

| File | Stage | Size | Format |
|---|---|---|---|
| `wilddet3d_stage1_omni3d_12e_v1.0.pt` | Stage 1 (Omni3D-only canonical, 12 ep) | ~4.7 GB | same as v1.0.pt |
| `wilddet3d_stage2_alldata_12e_v1.0.pt` | Stage 2 (8-dataset all-data finetune, 12 ep) | ~4.7 GB | same as v1.0.pt |
| `wilddet3d_alldata_all_prompt_v1.0.pt` | Stage 3 (paper) | ~4.7 GB | already released |

Both new ckpts are state_dict + epoch/step + hparams only (optimizer state stripped), loadable via `wilddet3d.build_model(checkpoint=..., skip_pretrained=True)` exactly like the existing v1.0.pt release.

## Doc changes

- `README.md`: add an "Intermediate checkpoints" section under the existing paper-ckpt download block, with `huggingface-cli download` commands for both new files.
- `docs/TRAINING.md`: add "Skip Stage 1" / "Skip Stage 2" notes inside the per-stage subsections so users only reproducing Stage 3 (e.g. the request in #20) can `--ckpt` straight into the next stage without running 12 epochs of upstream training.

Closes #20.
